### PR TITLE
Allow builds to fail for Python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,8 @@ matrix:
       sudo: required
       env:
         - TOXENV=py37-nocov
+  allow_failures:
+    - python: '3.7'
 before_install:
   - python --version
   - uname -a

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -101,6 +101,10 @@ environment:
       PYTHON_VERSION: '3.7'
       PYTHON_ARCH: '64'
 
+matrix:
+  allow_failures:
+    - PYTHON_VERSION: '3.7'
+
 init:
   - ps: echo $env:TOXENV
   - ps: ls C:\Python*

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,6 @@ setup(
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: Implementation :: CPython",
         # uncomment if you test on these interpreters:
         # 'Programming Language :: Python :: Implementation :: IronPython',

--- a/tox.ini
+++ b/tox.ini
@@ -153,9 +153,11 @@ commands =
 deps =
     {[testenv]deps}
     pytest-cov
+ignore_errors = True
 
 [testenv:py37-nocov]
 basepython = {env:TOXPYTHON:python3.7}
+ignore_errors = True
 
 
 


### PR DESCRIPTION
They will fail anyway, until the problem with `pyproj` is solved.