### PR TITLE
Proposal for raising facade specific exceptions

### DIFF
--- a/src/oemof/tabular/facades.py
+++ b/src/oemof/tabular/facades.py
@@ -119,6 +119,7 @@ class Facade(Node):
 
         return self.investment
 
+
     def update(self):
         self.build_solph_components()
 
@@ -487,7 +488,11 @@ class Volatile(Source, Facade):
 
         self.fixed = bool(kwargs.get("fixed", True))
 
-        self.build_solph_components()
+        try:
+            self.build_solph_components()
+        except:
+            raise Exception(
+                "Error in instantiating Facade {}.".format(self.label))
 
     def build_solph_components(self):
         """


### PR DESCRIPTION
Debugging is kind of tricky with the datapackage reader in combination with solph. The user would strongly benifit from an information for what facade an error occurs when the instantiation fails. 

see proposal below, please suggest a better solution that can be implemented at a central place for all facades...