### PR TITLE
Set marginal cost on both directions

### DIFF
--- a/src/oemof/tabular/facades.py
+++ b/src/oemof/tabular/facades.py
@@ -1421,6 +1421,7 @@ class Link(Link, Facade):
                     investment=investment,
                 ),
                 self.to_bus: Flow(
+                    variable_costs=self.marginal_cost,
                     nominal_value=self._nominal_value()["from_to"],
                     investment=investment
                 ),


### PR DESCRIPTION
You can set `marginal_cost` on the links. This can be helpful because it prevents the model from destroying energy through loop flows instead of using curtailment.

Until now, marginal cost are set only to one exit, not both. This has the effect that there are marginal cost for flows in one direction, but none in the other. 

This PR fixes that by setting `marginal_cost` for both output flows.