### PR TITLE
Fix Link investment

### DIFF
--- a/src/oemof/tabular/facades.py
+++ b/src/oemof/tabular/facades.py
@@ -76,7 +76,12 @@ class Facade(Node):
         the capacity
         """
         if self.expandable is True:
-            return None
+            if isinstance(self, Link):
+                return {
+                    "from_to": None,
+                    "to_from": None}
+            else:
+                return None
 
         else:
             if isinstance(self, Link):


### PR DESCRIPTION
When running datapackages with expandable Links, `_nominal_value` returns None, but in `Link`, a dictionary is expected. This gives the following error:

```
  File "oemof/tabular/datapackage/reading.py", line 408, in deserialize_energy_system
    resource,
  File "oemof/tabular/datapackage/reading.py", line 102, in read_facade
    instance = create(mapping, facade, facade)
  File "oemof/tabular/datapackage/reading.py", line 288, in create
    instance = cls(**remap(init, attributemap, cls))
  File "oemof/tabular/facades.py", line 1407, in __init__
    self.build_solph_components()
  File "oemof/tabular/facades.py", line 1420, in build_solph_components
    nominal_value=self._nominal_value()["to_from"],
TypeError: 'NoneType' object is not subscriptable

```

This PR fixes that bug by introducing a conditional for the case of capacity expansion in `_nominal_value`. 