### PR TITLE
Facades as dataclasses

### DIFF
--- a/src/oemof/tabular/facades.py
+++ b/src/oemof/tabular/facades.py
@@ -299,7 +299,8 @@ class Reservoir(GenericStorage, Facade):
 
         self.subnodes = (inflow,)
 
-
+@dataclass
+@kwargs_to_parent
 class Dispatchable(Source, Facade):
     r""" Dispatchable element with one output for example a gas-turbine
 
@@ -383,28 +384,25 @@ class Dispatchable(Source, Facade):
     ...         'min': 0.2})
 
     """
+    bus: Bus
 
-    def __init__(self, *args, **kwargs):
-        kwargs.update({"_facade_requires_": ["bus", "carrier", "tech"]})
-        super().__init__(*args, **kwargs)
+    carrier: str
 
-        self.profile = kwargs.get("profile", 1)
+    tech: str
 
-        self.capacity = kwargs.get("capacity")
+    profile: float = 1
 
-        self.capacity_potential = kwargs.get("capacity_potential")
+    capacity: float = 0
 
-        self.marginal_cost = kwargs.get("marginal_cost", 0)
+    capacity_potential: float = float("+inf")
 
-        self.capacity_cost = kwargs.get("capacity_cost")
+    marginal_cost: float = 0
 
-        self.capacity_minimum = kwargs.get("capacity_minimum")
+    capacity_cost: float = 0
 
-        self.expandable = bool(kwargs.get("expandable", False))
+    capacity_minimum: float = 0
 
-        self.output_parameters = kwargs.get("output_parameters", {})
-
-        self.build_solph_components()
+    expandable: bool = False
 
     def build_solph_components(self):
         """

--- a/src/oemof/tabular/facades.py
+++ b/src/oemof/tabular/facades.py
@@ -299,7 +299,7 @@ class Reservoir(GenericStorage, Facade):
 
         self.subnodes = (inflow,)
 
-@dataclass
+@dataclass(unsafe_hash=True)
 @kwargs_to_parent
 class Dispatchable(Source, Facade):
     r""" Dispatchable element with one output for example a gas-turbine
@@ -1198,7 +1198,7 @@ class Load(Sink, Facade):
         )
 
 
-@dataclass
+@dataclass(unsafe_hash=True)
 @kwargs_to_parent
 class Storage(GenericStorage, Facade):
     r""" Storage unit

--- a/src/oemof/tabular/facades.py
+++ b/src/oemof/tabular/facades.py
@@ -299,8 +299,8 @@ class Reservoir(GenericStorage, Facade):
 
         self.subnodes = (inflow,)
 
-@dataclass(unsafe_hash=True)
 @kwargs_to_parent
+@dataclass(unsafe_hash=True)
 class Dispatchable(Source, Facade):
     r""" Dispatchable element with one output for example a gas-turbine
 
@@ -1198,8 +1198,8 @@ class Load(Sink, Facade):
         )
 
 
-@dataclass(unsafe_hash=True)
 @kwargs_to_parent
+@dataclass(unsafe_hash=True)
 class Storage(GenericStorage, Facade):
     r""" Storage unit
 

--- a/src/oemof/tabular/facades.py
+++ b/src/oemof/tabular/facades.py
@@ -301,8 +301,8 @@ class Reservoir(GenericStorage, Facade):
 
         self.subnodes = (inflow,)
 
-@kwargs_to_parent
-@dataclass(unsafe_hash=True)
+@kwargs_to_parent  # second, decorate to handle kwargs in __init__
+@dataclass(unsafe_hash=True)  # first decorate as dataclasse
 class Dispatchable(Source, Facade):
     r""" Dispatchable element with one output for example a gas-turbine
 

--- a/src/oemof/tabular/facades.py
+++ b/src/oemof/tabular/facades.py
@@ -1278,7 +1278,7 @@ class Storage(GenericStorage, Facade):
     ...        max_storage_level=[0.9, 0.95, 0.8])) # oemof.solph argument
 
     """
-    bus: str
+    bus: Bus
 
     carrier: str
 

--- a/src/oemof/tabular/facades.py
+++ b/src/oemof/tabular/facades.py
@@ -48,6 +48,8 @@ def kwargs_to_parent(cls):
 
         original_init(self, **dataclass_kwargs)
 
+        self.build_solph_components()
+
     cls.__init__ = new_init
     return cls
 
@@ -1303,10 +1305,6 @@ class Storage(GenericStorage, Facade):
     input_parameters: dict = None
 
     output_parameters:dict = None
-
-    def __post_init__(self, *args, **kwargs):
-
-        self.build_solph_components()
 
     def build_solph_components(self):
         """

--- a/src/oemof/tabular/facades.py
+++ b/src/oemof/tabular/facades.py
@@ -37,6 +37,19 @@ warnings.filterwarnings("ignore", category=SuspiciousUsageWarning)
 
 
 def kwargs_to_parent(cls):
+    r"""
+    Decorates the __init__ of a given class by first
+    passing args and kwargs to the __init__ of the parent
+    class.
+
+    Parameters
+    ----------
+    cls : Class with an __init__ to decorate
+
+    Returns
+    -------
+    cls : Class with decorated __init__
+    """
     original_init = cls.__init__
 
     def new_init(self, *args, **kwargs):

--- a/src/oemof/tabular/facades.py
+++ b/src/oemof/tabular/facades.py
@@ -302,7 +302,7 @@ class Reservoir(GenericStorage, Facade):
         self.subnodes = (inflow,)
 
 @kwargs_to_parent  # second, decorate to handle kwargs in __init__
-@dataclass(unsafe_hash=True)  # first decorate as dataclasse
+@dataclass(unsafe_hash=False, frozen=False, eq=False)  # first decorate as dataclasse
 class Dispatchable(Source, Facade):
     r""" Dispatchable element with one output for example a gas-turbine
 
@@ -1203,7 +1203,7 @@ class Load(Sink, Facade):
 
 
 @kwargs_to_parent
-@dataclass(unsafe_hash=True)
+@dataclass(unsafe_hash=False, frozen=False, eq=False)
 class Storage(GenericStorage, Facade):
     r""" Storage unit
 

--- a/src/oemof/tabular/facades.py
+++ b/src/oemof/tabular/facades.py
@@ -406,6 +406,8 @@ class Dispatchable(Source, Facade):
 
     expandable: bool = False
 
+    output_parameters: dict = field(default_factory=dict)
+
     def build_solph_components(self):
         """
         """
@@ -1302,9 +1304,9 @@ class Storage(GenericStorage, Facade):
 
     efficiency: float = 1
 
-    input_parameters: dict = None
+    input_parameters: dict = field(default_factory=dict)
 
-    output_parameters:dict = None
+    output_parameters: dict = field(default_factory=dict)
 
     def build_solph_components(self):
         """


### PR DESCRIPTION
This is a draft to show how facades can be implemented as dataclasses. The advantages are:

* explicit definition of class attributes
* type annotation
* Clearer handling of required and default arguments

Problems encountered:

* the facades original `__init__` passes args and kwargs to the parent class (with `super().__init__(*args, **kwargs)`, which makes it possible to set attributes of the base class that are not explicit in the facade (like `invest_relation_output_capacity` for storage). To keep this behaviour, I implemented a wrapper that adds that call to the `__init__`.
* Declaring the facade as dataclass may override the `__hash__` method that is defined in oemof.network.Node (the hash of the class is defined as the hash of the label). Applying the correct settings, the `__hash__` method remains untouched.
 