### PR TITLE
Fix ImportError by not importing aggregation when importing datapackage

### DIFF
--- a/src/oemof/tabular/datapackage/__init__.py
+++ b/src/oemof/tabular/datapackage/__init__.py
@@ -1,6 +1,5 @@
 from oemof.network.energy_system import EnergySystem
 
-from . import aggregation, building, processing  # noqa F401
 from .reading import deserialize_energy_system
 
 EnergySystem.from_datapackage = classmethod(deserialize_energy_system)

--- a/src/oemof/tabular/datapackage/__init__.py
+++ b/src/oemof/tabular/datapackage/__init__.py
@@ -1,6 +1,6 @@
 from oemof.network.energy_system import EnergySystem
 
-from . import building
+from . import building  # noqa F401
 from .reading import deserialize_energy_system
 
 EnergySystem.from_datapackage = classmethod(deserialize_energy_system)

--- a/src/oemof/tabular/datapackage/__init__.py
+++ b/src/oemof/tabular/datapackage/__init__.py
@@ -1,5 +1,6 @@
 from oemof.network.energy_system import EnergySystem
 
+from . import building
 from .reading import deserialize_energy_system
 
 EnergySystem.from_datapackage = classmethod(deserialize_energy_system)


### PR DESCRIPTION
When importing oemof.tabular.datapackage, aggregation is imported via datapackage/__init__.py, which gives an ImportError when the extra requirement "tsam" is not installed. Aggregation should only be imported when imported explicitly.

Fixes a failing test in https://github.com/rl-institut/oemoflex/pull/74