### PR TITLE
Update OS compatible paths in config.py

### DIFF
--- a/src/oemof/tabular/config/config.py
+++ b/src/oemof/tabular/config/config.py
@@ -3,11 +3,11 @@ import json
 import os
 import pathlib
 
-CONFIG_FOLDER = pathlib.PurePosixPath(__file__).parent
+CONFIG_FOLDER = pathlib.PurePath(__file__).parent
 
 FOREIGN_KEYS_FILE = os.environ.get(
     "OEMOF_TABULAR_FOREIGN_KEYS_FILE",
-    CONFIG_FOLDER / "foreign_keys.json"
+    pathlib.Path(CONFIG_FOLDER, "foreign_keys.json")
 )
 with open(FOREIGN_KEYS_FILE, "r") as fk_file:
     FOREIGN_KEYS = json.load(fk_file)


### PR DESCRIPTION
This PR tracks the fixes of paths, in order to make them compatible on both Linux and Windows machines. 
This should resolve errors that occur if `infer_metadata()` is triggered in `building.py`

**update**: Here, the bug on windows caused by config.py is fixed. The original bug described in #27 remains.