### PR TITLE
Updated tableschema to v1.7.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ setup(
     ],
     install_requires=[
         "datapackage==1.5.1",
-        "tableschema==1.3.0",
+        "tableschema==1.7.4",  # newer versions (v1.8.0 and up) fail!
         "oemof.solph @ git+https://git@github.com/oemof/oemof-solph@v0.4#egg=oemof.solph",
         "pandas>=0.22",
         "paramiko",


### PR DESCRIPTION
This allows other apps to install jsonschema>=2.5 (which is not allowed in tableschema below 1.4.1).
See discussion here: https://github.com/rl-institut-private/digiplan/issues/96
Version 1.7.4 is newest working version (newer versions fail due to foreign key errors in files)

Tests are working with this version (latest versions fails)