### PR TITLE
Fix paths to infer metadata correctly on Windows/Linux

### DIFF
--- a/src/oemof/tabular/datapackage/building.py
+++ b/src/oemof/tabular/datapackage/building.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import pathlib
 from ftplib import FTP
 from urllib.parse import urlparse
 import errno
@@ -8,7 +9,6 @@ import sys
 import tarfile
 import urllib.request
 import zipfile
-from pathlib import PurePosixPath
 
 from datapackage import Package, Resource
 import pandas as pd
@@ -105,7 +105,7 @@ def infer_metadata(
         )
     else:
         for f in os.listdir("data/elements"):
-            r = Resource({"path": str(PurePosixPath("data", "elements", f))})
+            r = Resource({"path": str(pathlib.PurePosixPath("data", "elements", f))})
             r.infer()
             r.descriptor["schema"]["primaryKey"] = "name"
 
@@ -139,7 +139,7 @@ def infer_metadata(
                         )
 
             r.commit()
-            r.save(PurePosixPath("resources", f.replace(".csv", ".json")))
+            r.save(pathlib.PurePosixPath("resources", f.replace(".csv", ".json")))
             p.add_resource(r.descriptor)
 
     # create meta data resources sequences
@@ -151,10 +151,10 @@ def infer_metadata(
         )
     else:
         for f in os.listdir("data/sequences"):
-            r = Resource({"path": str(PurePosixPath("data", "sequences", f))})
+            r = Resource({"path": str(pathlib.PurePosixPath("data", "sequences", f))})
             r.infer()
             r.commit()
-            r.save(PurePosixPath("resources", f.replace(".csv", ".json")))
+            r.save(pathlib.PurePosixPath("resources", f.replace(".csv", ".json")))
             p.add_resource(r.descriptor)
 
     if not os.path.exists("data/geometries"):
@@ -165,10 +165,10 @@ def infer_metadata(
         )
     else:
         for f in os.listdir("data/geometries"):
-            r = Resource({"path": str(PurePosixPath("data", "geometries", f))})
+            r = Resource({"path": str(pathlib.PurePosixPath("data", "geometries", f))})
             r.infer()
             r.commit()
-            r.save(PurePosixPath("resources", f.replace(".csv", ".json")))
+            r.save(pathlib.PurePosixPath("resources", f.replace(".csv", ".json")))
             p.add_resource(r.descriptor)
 
     p.commit()

--- a/src/oemof/tabular/datapackage/building.py
+++ b/src/oemof/tabular/datapackage/building.py
@@ -140,7 +140,7 @@ def infer_metadata(
                         )
 
             r.commit()
-            r.save(os.path.join("resources", f.replace(".csv", ".json")))
+            r.save(pathlib.PurePosixPath("resources", f.replace(".csv", ".json")))
             p.add_resource(r.descriptor)
 
     # create meta data resources sequences

--- a/src/oemof/tabular/datapackage/building.py
+++ b/src/oemof/tabular/datapackage/building.py
@@ -152,7 +152,7 @@ def infer_metadata(
         )
     else:
         for f in os.listdir("data/sequences"):
-            r = Resource({"path": os.path.join("data/sequences", f)})
+            r = Resource({"path": str(pathlib.PurePosixPath("data", "sequences", f))})
             r.infer()
             r.commit()
             r.save(os.path.join("resources", f.replace(".csv", ".json")))

--- a/src/oemof/tabular/datapackage/building.py
+++ b/src/oemof/tabular/datapackage/building.py
@@ -9,7 +9,6 @@ import sys
 import tarfile
 import urllib.request
 import zipfile
-import pathlib
 
 from datapackage import Package, Resource
 import pandas as pd
@@ -166,10 +165,10 @@ def infer_metadata(
         )
     else:
         for f in os.listdir("data/geometries"):
-            r = Resource({"path": os.path.join("data/geometries", f)})
+            r = Resource({"path": str(pathlib.PurePosixPath("data", "geometries", f))})
             r.infer()
             r.commit()
-            r.save(os.path.join("resources", f.replace(".csv", ".json")))
+            r.save(pathlib.PurePosixPath("resources", f.replace(".csv", ".json")))
             p.add_resource(r.descriptor)
 
     p.commit()

--- a/src/oemof/tabular/datapackage/building.py
+++ b/src/oemof/tabular/datapackage/building.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
-import pathlib
 from ftplib import FTP
 from urllib.parse import urlparse
 import errno
 import os
+import pathlib
 import shutil
 import sys
 import tarfile

--- a/src/oemof/tabular/datapackage/building.py
+++ b/src/oemof/tabular/datapackage/building.py
@@ -105,7 +105,8 @@ def infer_metadata(
         )
     else:
         for f in os.listdir("data/elements"):
-            r = Resource({"path": str(pathlib.PurePosixPath("data", "elements", f))})
+            r = Resource({"path": str(pathlib.PurePosixPath(
+                "data", "elements", f))})
             r.infer()
             r.descriptor["schema"]["primaryKey"] = "name"
 
@@ -139,7 +140,8 @@ def infer_metadata(
                         )
 
             r.commit()
-            r.save(pathlib.PurePosixPath("resources", f.replace(".csv", ".json")))
+            r.save(pathlib.PurePosixPath("resources", f.replace(
+                ".csv", ".json")))
             p.add_resource(r.descriptor)
 
     # create meta data resources sequences
@@ -151,10 +153,12 @@ def infer_metadata(
         )
     else:
         for f in os.listdir("data/sequences"):
-            r = Resource({"path": str(pathlib.PurePosixPath("data", "sequences", f))})
+            r = Resource({"path": str(pathlib.PurePosixPath(
+                "data", "sequences", f))})
             r.infer()
             r.commit()
-            r.save(pathlib.PurePosixPath("resources", f.replace(".csv", ".json")))
+            r.save(pathlib.PurePosixPath("resources", f.replace(
+                ".csv", ".json")))
             p.add_resource(r.descriptor)
 
     if not os.path.exists("data/geometries"):
@@ -165,10 +169,12 @@ def infer_metadata(
         )
     else:
         for f in os.listdir("data/geometries"):
-            r = Resource({"path": str(pathlib.PurePosixPath("data", "geometries", f))})
+            r = Resource({"path": str(pathlib.PurePosixPath(
+                "data", "geometries", f))})
             r.infer()
             r.commit()
-            r.save(pathlib.PurePosixPath("resources", f.replace(".csv", ".json")))
+            r.save(pathlib.PurePosixPath("resources", f.replace(
+                ".csv", ".json")))
             p.add_resource(r.descriptor)
 
     p.commit()

--- a/src/oemof/tabular/datapackage/building.py
+++ b/src/oemof/tabular/datapackage/building.py
@@ -155,7 +155,7 @@ def infer_metadata(
             r = Resource({"path": str(pathlib.PurePosixPath("data", "sequences", f))})
             r.infer()
             r.commit()
-            r.save(os.pathlib.PurePosixPath("resources", f.replace(".csv", ".json")))
+            r.save(pathlib.PurePosixPath("resources", f.replace(".csv", ".json")))
             p.add_resource(r.descriptor)
 
     if not os.path.exists("data/geometries"):

--- a/src/oemof/tabular/datapackage/building.py
+++ b/src/oemof/tabular/datapackage/building.py
@@ -155,7 +155,7 @@ def infer_metadata(
             r = Resource({"path": str(pathlib.PurePosixPath("data", "sequences", f))})
             r.infer()
             r.commit()
-            r.save(os.path.join("resources", f.replace(".csv", ".json")))
+            r.save(os.pathlib.PurePosixPath("resources", f.replace(".csv", ".json")))
             p.add_resource(r.descriptor)
 
     if not os.path.exists("data/geometries"):

--- a/src/oemof/tabular/datapackage/building.py
+++ b/src/oemof/tabular/datapackage/building.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-import pathlib
 from ftplib import FTP
 from urllib.parse import urlparse
 import errno
@@ -9,6 +8,7 @@ import sys
 import tarfile
 import urllib.request
 import zipfile
+from pathlib import PurePosixPath
 
 from datapackage import Package, Resource
 import pandas as pd
@@ -105,7 +105,7 @@ def infer_metadata(
         )
     else:
         for f in os.listdir("data/elements"):
-            r = Resource({"path": str(pathlib.PurePosixPath("data", "elements", f))})
+            r = Resource({"path": str(PurePosixPath("data", "elements", f))})
             r.infer()
             r.descriptor["schema"]["primaryKey"] = "name"
 
@@ -139,7 +139,7 @@ def infer_metadata(
                         )
 
             r.commit()
-            r.save(pathlib.PurePosixPath("resources", f.replace(".csv", ".json")))
+            r.save(PurePosixPath("resources", f.replace(".csv", ".json")))
             p.add_resource(r.descriptor)
 
     # create meta data resources sequences
@@ -151,10 +151,10 @@ def infer_metadata(
         )
     else:
         for f in os.listdir("data/sequences"):
-            r = Resource({"path": str(pathlib.PurePosixPath("data", "sequences", f))})
+            r = Resource({"path": str(PurePosixPath("data", "sequences", f))})
             r.infer()
             r.commit()
-            r.save(pathlib.PurePosixPath("resources", f.replace(".csv", ".json")))
+            r.save(PurePosixPath("resources", f.replace(".csv", ".json")))
             p.add_resource(r.descriptor)
 
     if not os.path.exists("data/geometries"):
@@ -165,10 +165,10 @@ def infer_metadata(
         )
     else:
         for f in os.listdir("data/geometries"):
-            r = Resource({"path": str(pathlib.PurePosixPath("data", "geometries", f))})
+            r = Resource({"path": str(PurePosixPath("data", "geometries", f))})
             r.infer()
             r.commit()
-            r.save(pathlib.PurePosixPath("resources", f.replace(".csv", ".json")))
+            r.save(PurePosixPath("resources", f.replace(".csv", ".json")))
             p.add_resource(r.descriptor)
 
     p.commit()

--- a/src/oemof/tabular/datapackage/building.py
+++ b/src/oemof/tabular/datapackage/building.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import pathlib
 from ftplib import FTP
 from urllib.parse import urlparse
 import errno
@@ -8,6 +9,7 @@ import sys
 import tarfile
 import urllib.request
 import zipfile
+import pathlib
 
 from datapackage import Package, Resource
 import pandas as pd
@@ -104,7 +106,7 @@ def infer_metadata(
         )
     else:
         for f in os.listdir("data/elements"):
-            r = Resource({"path": os.path.join("data/elements", f)})
+            r = Resource({"path": str(pathlib.PurePosixPath("data", "elements", f))})
             r.infer()
             r.descriptor["schema"]["primaryKey"] = "name"
 


### PR DESCRIPTION
This PR tracks the fixes made to paths in `buildings.py` `infer_metadata()`. Paths that were indicated with `os.path.join`  caused errors on Windows operating systems and are replaced with `pathlib.PurePosixPath` 