### PR TITLE
Setup with `oemof.solph` dev-branch

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ setup(
         "datapackage==1.5.1",
         "tableschema==1.7.4",  # newer versions (v1.8.0 and up) fail!
         # "oemof.solph==0.5.1",
-        "oemof.solph @ git+https://github.com/oemof/oemof-solph.git@v0.5.1.dev2",
+        "oemof.solph @ git+https://github.com/oemof/oemof-solph.git@dev",
         "pandas>=0.22",
         "paramiko",
         "toml",

--- a/src/oemof/tabular/tools/postprocessing.py
+++ b/src/oemof/tabular/tools/postprocessing.py
@@ -21,7 +21,7 @@ def component_results(es, results, select="sequences"):
         setattr(es, "typemap", facades.TYPEMAP)
 
     for k, v in es.typemap.items():
-        if type(k) == str:
+        if isinstance(k, str):
             if select == "sequences":
                 _seq_by_type = [
                     views.node(results, n, multiindex=True).get("sequences")


### PR DESCRIPTION
With this PR, `dev` branch is used for installation as a version of `oemof.solph` to keep tabular up-to-date.