### PR TITLE
Add wrapper to enhance info on failed facade creation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,7 @@ Features
 
 * Improve reading error message `#134 <https://github.com/oemof/oemof-tabular/pull/134>`_
 * Remove facade relicts `#135 <https://github.com/oemof/oemof-tabular/pull/135>`_
+* Reading error enhancer `#145 <https://github.com/oemof/oemof-tabular/pull/145>`_
 
 Fixes
 

--- a/src/oemof/tabular/datapackage/reading.py
+++ b/src/oemof/tabular/datapackage/reading.py
@@ -29,6 +29,28 @@ DEFAULT = object()
 FLOW_TYPE = object()
 
 
+def error_enhancer(func):
+    def wrapper(*args, **kwargs):
+        try:
+            return func(*args, **kwargs)
+        except Exception as e:
+            # Add additional information to the error message
+            facade_type = args[0].get("type", None)
+            facade_name = args[0].get("name", None)
+            if facade_type is not None and facade_name is not None:
+                additional_info = (
+                    f"\nFailed creating '{facade_type}' with "
+                    f"name '{facade_name}'."
+                )
+                new_error_message = f"{str(e)} - {additional_info}"
+            else:
+                new_error_message = str(e)
+            # Raise the enhanced error
+            raise type(e)(new_error_message).with_traceback(e.__traceback__)
+
+    return wrapper
+
+
 def sequences(r, timeindices=None):
     """Parses the resource `r` as a sequence."""
     result = {
@@ -44,6 +66,7 @@ def sequences(r, timeindices=None):
     return result
 
 
+@error_enhancer
 def read_facade(
     facade,
     facades,


### PR DESCRIPTION
# Description

This wrapper catches errors while creating the facade in the reading module. This way, at least some information on which facade failed and where to look in the data are supplied.


## Type of change

Please tick or delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

Please tick or delete options that are not relevant.

- [x] New and adjusted code is formatted using the `pre-commit` hooks
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have added new features/fixes to the [CHANGELOG](https://github.com/oemof/oemof-tabular/tree/dev/CHANGELOG.rst)

