### PR TITLE
Upgrade to oemof.solph 0.5.2dev1

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -13,3 +13,4 @@ Authors
 * Sarah Berendes
 * Marie-Claire Gering
 * Julian Endres
+* Felix Maurer

--- a/setup.py
+++ b/setup.py
@@ -68,6 +68,8 @@ setup(
         "datapackage==1.5.1",
         "tableschema==1.7.4",  # newer versions (v1.8.0 and up) fail!
         # "oemof.solph>=0.5.1",
+        # Upcomming upgrade to solph 0.5.2 postponed due to many changes necessary for implementing
+        # explicit arguments and upgrade to network 0.5.1
         "oemof.solph==0.5.2dev2",
         "pandas>=0.22",
         "oemof.network==0.5.0a4",  # Temporal fix due to braking changes in 0.5.1

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ setup(
         "datapackage==1.5.1",
         "tableschema==1.7.4",  # newer versions (v1.8.0 and up) fail!
         # "oemof.solph>=0.5.1",
-        "oemof.solph==0.5.2dev0",
+        "oemof.solph==0.5.2dev2",
         "pandas>=0.22",
         "oemof.network==0.5.0a4",  # Temporal fix due to braking changes in 0.5.1
         "paramiko",

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ setup(
         # "oemof.solph>=0.5.1",
         # Upcomming upgrade to solph 0.5.2 postponed due to many changes necessary for implementing
         # explicit arguments and upgrade to network 0.5.1
-        "oemof.solph==0.5.2dev2",
+        "oemof.solph==0.5.2dev1",
         "pandas>=0.22",
         "oemof.network==0.5.0a4",  # Temporal fix due to braking changes in 0.5.1
         "paramiko",

--- a/tests/_files/lp_files/multi-period/backpressure_investment_brown_field_multi_period.lp
+++ b/tests/_files/lp_files/multi-period/backpressure_investment_brown_field_multi_period.lp
@@ -1,11 +1,11 @@
 \* Source Pyomo model name=Model *\
 
-min
+min 
 objective:
 +393187.4631175658 ONE_VAR_CONSTANT
-+561.5105784699618 InvestmentFlowBlock_invest(backpressure_electricity_0)
-+386.89361416194254 InvestmentFlowBlock_invest(backpressure_electricity_1)
-+267.76218567632424 InvestmentFlowBlock_invest(backpressure_electricity_2)
++550.3538603446715 InvestmentFlowBlock_invest(backpressure_electricity_0)
++226.09002140491177 InvestmentFlowBlock_invest(backpressure_electricity_1)
++15.604198638169356 InvestmentFlowBlock_invest(backpressure_electricity_2)
 +0.6 flow(fuel_backpressure_0_0)
 +0.6 flow(fuel_backpressure_0_1)
 +0.6 flow(fuel_backpressure_0_2)
@@ -18,40 +18,40 @@ objective:
 
 s.t.
 
-c_e_BusBlock_balance(heat_0_0)_:
-+1 flow(backpressure_heat_0_0)
+c_e_BusBlock_balance(electricity_0_0)_:
++1 flow(backpressure_electricity_0_0)
 = 0
 
-c_e_BusBlock_balance(heat_0_1)_:
-+1 flow(backpressure_heat_0_1)
+c_e_BusBlock_balance(electricity_0_1)_:
++1 flow(backpressure_electricity_0_1)
 = 0
 
-c_e_BusBlock_balance(heat_0_2)_:
-+1 flow(backpressure_heat_0_2)
+c_e_BusBlock_balance(electricity_0_2)_:
++1 flow(backpressure_electricity_0_2)
 = 0
 
-c_e_BusBlock_balance(heat_1_3)_:
-+1 flow(backpressure_heat_1_3)
+c_e_BusBlock_balance(electricity_1_3)_:
++1 flow(backpressure_electricity_1_3)
 = 0
 
-c_e_BusBlock_balance(heat_1_4)_:
-+1 flow(backpressure_heat_1_4)
+c_e_BusBlock_balance(electricity_1_4)_:
++1 flow(backpressure_electricity_1_4)
 = 0
 
-c_e_BusBlock_balance(heat_1_5)_:
-+1 flow(backpressure_heat_1_5)
+c_e_BusBlock_balance(electricity_1_5)_:
++1 flow(backpressure_electricity_1_5)
 = 0
 
-c_e_BusBlock_balance(heat_2_6)_:
-+1 flow(backpressure_heat_2_6)
+c_e_BusBlock_balance(electricity_2_6)_:
++1 flow(backpressure_electricity_2_6)
 = 0
 
-c_e_BusBlock_balance(heat_2_7)_:
-+1 flow(backpressure_heat_2_7)
+c_e_BusBlock_balance(electricity_2_7)_:
++1 flow(backpressure_electricity_2_7)
 = 0
 
-c_e_BusBlock_balance(heat_2_8)_:
-+1 flow(backpressure_heat_2_8)
+c_e_BusBlock_balance(electricity_2_8)_:
++1 flow(backpressure_electricity_2_8)
 = 0
 
 c_e_BusBlock_balance(fuel_0_0)_:
@@ -90,40 +90,40 @@ c_e_BusBlock_balance(fuel_2_8)_:
 +1 flow(fuel_backpressure_2_8)
 = 0
 
-c_e_BusBlock_balance(electricity_0_0)_:
-+1 flow(backpressure_electricity_0_0)
+c_e_BusBlock_balance(heat_0_0)_:
++1 flow(backpressure_heat_0_0)
 = 0
 
-c_e_BusBlock_balance(electricity_0_1)_:
-+1 flow(backpressure_electricity_0_1)
+c_e_BusBlock_balance(heat_0_1)_:
++1 flow(backpressure_heat_0_1)
 = 0
 
-c_e_BusBlock_balance(electricity_0_2)_:
-+1 flow(backpressure_electricity_0_2)
+c_e_BusBlock_balance(heat_0_2)_:
++1 flow(backpressure_heat_0_2)
 = 0
 
-c_e_BusBlock_balance(electricity_1_3)_:
-+1 flow(backpressure_electricity_1_3)
+c_e_BusBlock_balance(heat_1_3)_:
++1 flow(backpressure_heat_1_3)
 = 0
 
-c_e_BusBlock_balance(electricity_1_4)_:
-+1 flow(backpressure_electricity_1_4)
+c_e_BusBlock_balance(heat_1_4)_:
++1 flow(backpressure_heat_1_4)
 = 0
 
-c_e_BusBlock_balance(electricity_1_5)_:
-+1 flow(backpressure_electricity_1_5)
+c_e_BusBlock_balance(heat_1_5)_:
++1 flow(backpressure_heat_1_5)
 = 0
 
-c_e_BusBlock_balance(electricity_2_6)_:
-+1 flow(backpressure_electricity_2_6)
+c_e_BusBlock_balance(heat_2_6)_:
++1 flow(backpressure_heat_2_6)
 = 0
 
-c_e_BusBlock_balance(electricity_2_7)_:
-+1 flow(backpressure_electricity_2_7)
+c_e_BusBlock_balance(heat_2_7)_:
++1 flow(backpressure_heat_2_7)
 = 0
 
-c_e_BusBlock_balance(electricity_2_8)_:
-+1 flow(backpressure_electricity_2_8)
+c_e_BusBlock_balance(heat_2_8)_:
++1 flow(backpressure_heat_2_8)
 = 0
 
 c_e_ConverterBlock_relation(backpressure_fuel_electricity_0_0)_:
@@ -261,9 +261,9 @@ c_e_InvestmentFlowBlock_old_rule_exo(backpressure_electricity_2)_:
 = 1000
 
 c_e_InvestmentFlowBlock_old_rule(backpressure_electricity_0)_:
++1 InvestmentFlowBlock_old(backpressure_electricity_0)
 -1 InvestmentFlowBlock_old_end(backpressure_electricity_0)
 -1 InvestmentFlowBlock_old_exo(backpressure_electricity_0)
-+1 InvestmentFlowBlock_old(backpressure_electricity_0)
 = 0
 
 c_e_InvestmentFlowBlock_old_rule(backpressure_electricity_1)_:
@@ -337,15 +337,6 @@ bounds
    0 <= flow(fuel_backpressure_2_6) <= +inf
    0 <= flow(fuel_backpressure_2_7) <= +inf
    0 <= flow(fuel_backpressure_2_8) <= +inf
-   0 <= flow(backpressure_heat_0_0) <= +inf
-   0 <= flow(backpressure_heat_0_1) <= +inf
-   0 <= flow(backpressure_heat_0_2) <= +inf
-   0 <= flow(backpressure_heat_1_3) <= +inf
-   0 <= flow(backpressure_heat_1_4) <= +inf
-   0 <= flow(backpressure_heat_1_5) <= +inf
-   0 <= flow(backpressure_heat_2_6) <= +inf
-   0 <= flow(backpressure_heat_2_7) <= +inf
-   0 <= flow(backpressure_heat_2_8) <= +inf
    0 <= flow(backpressure_electricity_0_0) <= +inf
    0 <= flow(backpressure_electricity_0_1) <= +inf
    0 <= flow(backpressure_electricity_0_2) <= +inf
@@ -355,10 +346,20 @@ bounds
    0 <= flow(backpressure_electricity_2_6) <= +inf
    0 <= flow(backpressure_electricity_2_7) <= +inf
    0 <= flow(backpressure_electricity_2_8) <= +inf
+   0 <= flow(backpressure_heat_0_0) <= +inf
+   0 <= flow(backpressure_heat_0_1) <= +inf
+   0 <= flow(backpressure_heat_0_2) <= +inf
+   0 <= flow(backpressure_heat_1_3) <= +inf
+   0 <= flow(backpressure_heat_1_4) <= +inf
+   0 <= flow(backpressure_heat_1_5) <= +inf
+   0 <= flow(backpressure_heat_2_6) <= +inf
+   0 <= flow(backpressure_heat_2_7) <= +inf
+   0 <= flow(backpressure_heat_2_8) <= +inf
    0 <= InvestmentFlowBlock_total(backpressure_electricity_0) <= +inf
    0 <= InvestmentFlowBlock_total(backpressure_electricity_1) <= +inf
-   0 <= InvestmentFlowBlock_old(backpressure_electricity_1) <= +inf
    0 <= InvestmentFlowBlock_total(backpressure_electricity_2) <= +inf
+   0 <= InvestmentFlowBlock_old(backpressure_electricity_0) <= +inf
+   0 <= InvestmentFlowBlock_old(backpressure_electricity_1) <= +inf
    0 <= InvestmentFlowBlock_old(backpressure_electricity_2) <= +inf
    0 <= InvestmentFlowBlock_old_end(backpressure_electricity_0) <= +inf
    0 <= InvestmentFlowBlock_old_end(backpressure_electricity_1) <= +inf
@@ -366,5 +367,4 @@ bounds
    0 <= InvestmentFlowBlock_old_exo(backpressure_electricity_0) <= +inf
    0 <= InvestmentFlowBlock_old_exo(backpressure_electricity_1) <= +inf
    0 <= InvestmentFlowBlock_old_exo(backpressure_electricity_2) <= +inf
-   0 <= InvestmentFlowBlock_old(backpressure_electricity_0) <= +inf
 end

--- a/tests/_files/lp_files/multi-period/backpressure_investment_green_field_multi_period.lp
+++ b/tests/_files/lp_files/multi-period/backpressure_investment_green_field_multi_period.lp
@@ -1,10 +1,10 @@
 \* Source Pyomo model name=Model *\
 
-min
+min 
 objective:
-+561.5105784699618 InvestmentFlowBlock_invest(backpressure_bus_el_0)
-+386.89361416194254 InvestmentFlowBlock_invest(backpressure_bus_el_1)
-+267.76218567632424 InvestmentFlowBlock_invest(backpressure_bus_el_2)
++550.3538603446715 InvestmentFlowBlock_invest(backpressure_bus_el_0)
++226.09002140491177 InvestmentFlowBlock_invest(backpressure_bus_el_1)
++15.604198638169356 InvestmentFlowBlock_invest(backpressure_bus_el_2)
 +0.6 flow(bus_fuel_backpressure_0_0)
 +0.6 flow(bus_fuel_backpressure_0_1)
 +0.6 flow(bus_fuel_backpressure_0_2)
@@ -17,40 +17,40 @@ objective:
 
 s.t.
 
-c_e_BusBlock_balance(bus_heat_0_0)_:
-+1 flow(backpressure_bus_heat_0_0)
+c_e_BusBlock_balance(bus_el_0_0)_:
++1 flow(backpressure_bus_el_0_0)
 = 0
 
-c_e_BusBlock_balance(bus_heat_0_1)_:
-+1 flow(backpressure_bus_heat_0_1)
+c_e_BusBlock_balance(bus_el_0_1)_:
++1 flow(backpressure_bus_el_0_1)
 = 0
 
-c_e_BusBlock_balance(bus_heat_0_2)_:
-+1 flow(backpressure_bus_heat_0_2)
+c_e_BusBlock_balance(bus_el_0_2)_:
++1 flow(backpressure_bus_el_0_2)
 = 0
 
-c_e_BusBlock_balance(bus_heat_1_3)_:
-+1 flow(backpressure_bus_heat_1_3)
+c_e_BusBlock_balance(bus_el_1_3)_:
++1 flow(backpressure_bus_el_1_3)
 = 0
 
-c_e_BusBlock_balance(bus_heat_1_4)_:
-+1 flow(backpressure_bus_heat_1_4)
+c_e_BusBlock_balance(bus_el_1_4)_:
++1 flow(backpressure_bus_el_1_4)
 = 0
 
-c_e_BusBlock_balance(bus_heat_1_5)_:
-+1 flow(backpressure_bus_heat_1_5)
+c_e_BusBlock_balance(bus_el_1_5)_:
++1 flow(backpressure_bus_el_1_5)
 = 0
 
-c_e_BusBlock_balance(bus_heat_2_6)_:
-+1 flow(backpressure_bus_heat_2_6)
+c_e_BusBlock_balance(bus_el_2_6)_:
++1 flow(backpressure_bus_el_2_6)
 = 0
 
-c_e_BusBlock_balance(bus_heat_2_7)_:
-+1 flow(backpressure_bus_heat_2_7)
+c_e_BusBlock_balance(bus_el_2_7)_:
++1 flow(backpressure_bus_el_2_7)
 = 0
 
-c_e_BusBlock_balance(bus_heat_2_8)_:
-+1 flow(backpressure_bus_heat_2_8)
+c_e_BusBlock_balance(bus_el_2_8)_:
++1 flow(backpressure_bus_el_2_8)
 = 0
 
 c_e_BusBlock_balance(bus_fuel_0_0)_:
@@ -89,40 +89,40 @@ c_e_BusBlock_balance(bus_fuel_2_8)_:
 +1 flow(bus_fuel_backpressure_2_8)
 = 0
 
-c_e_BusBlock_balance(bus_el_0_0)_:
-+1 flow(backpressure_bus_el_0_0)
+c_e_BusBlock_balance(bus_heat_0_0)_:
++1 flow(backpressure_bus_heat_0_0)
 = 0
 
-c_e_BusBlock_balance(bus_el_0_1)_:
-+1 flow(backpressure_bus_el_0_1)
+c_e_BusBlock_balance(bus_heat_0_1)_:
++1 flow(backpressure_bus_heat_0_1)
 = 0
 
-c_e_BusBlock_balance(bus_el_0_2)_:
-+1 flow(backpressure_bus_el_0_2)
+c_e_BusBlock_balance(bus_heat_0_2)_:
++1 flow(backpressure_bus_heat_0_2)
 = 0
 
-c_e_BusBlock_balance(bus_el_1_3)_:
-+1 flow(backpressure_bus_el_1_3)
+c_e_BusBlock_balance(bus_heat_1_3)_:
++1 flow(backpressure_bus_heat_1_3)
 = 0
 
-c_e_BusBlock_balance(bus_el_1_4)_:
-+1 flow(backpressure_bus_el_1_4)
+c_e_BusBlock_balance(bus_heat_1_4)_:
++1 flow(backpressure_bus_heat_1_4)
 = 0
 
-c_e_BusBlock_balance(bus_el_1_5)_:
-+1 flow(backpressure_bus_el_1_5)
+c_e_BusBlock_balance(bus_heat_1_5)_:
++1 flow(backpressure_bus_heat_1_5)
 = 0
 
-c_e_BusBlock_balance(bus_el_2_6)_:
-+1 flow(backpressure_bus_el_2_6)
+c_e_BusBlock_balance(bus_heat_2_6)_:
++1 flow(backpressure_bus_heat_2_6)
 = 0
 
-c_e_BusBlock_balance(bus_el_2_7)_:
-+1 flow(backpressure_bus_el_2_7)
+c_e_BusBlock_balance(bus_heat_2_7)_:
++1 flow(backpressure_bus_heat_2_7)
 = 0
 
-c_e_BusBlock_balance(bus_el_2_8)_:
-+1 flow(backpressure_bus_el_2_8)
+c_e_BusBlock_balance(bus_heat_2_8)_:
++1 flow(backpressure_bus_heat_2_8)
 = 0
 
 c_e_ConverterBlock_relation(backpressure_bus_fuel_bus_el_0_0)_:
@@ -260,9 +260,9 @@ c_e_InvestmentFlowBlock_old_rule_exo(backpressure_bus_el_2)_:
 = 0
 
 c_e_InvestmentFlowBlock_old_rule(backpressure_bus_el_0)_:
++1 InvestmentFlowBlock_old(backpressure_bus_el_0)
 -1 InvestmentFlowBlock_old_end(backpressure_bus_el_0)
 -1 InvestmentFlowBlock_old_exo(backpressure_bus_el_0)
-+1 InvestmentFlowBlock_old(backpressure_bus_el_0)
 = 0
 
 c_e_InvestmentFlowBlock_old_rule(backpressure_bus_el_1)_:
@@ -335,15 +335,6 @@ bounds
    0 <= flow(bus_fuel_backpressure_2_6) <= +inf
    0 <= flow(bus_fuel_backpressure_2_7) <= +inf
    0 <= flow(bus_fuel_backpressure_2_8) <= +inf
-   0 <= flow(backpressure_bus_heat_0_0) <= +inf
-   0 <= flow(backpressure_bus_heat_0_1) <= +inf
-   0 <= flow(backpressure_bus_heat_0_2) <= +inf
-   0 <= flow(backpressure_bus_heat_1_3) <= +inf
-   0 <= flow(backpressure_bus_heat_1_4) <= +inf
-   0 <= flow(backpressure_bus_heat_1_5) <= +inf
-   0 <= flow(backpressure_bus_heat_2_6) <= +inf
-   0 <= flow(backpressure_bus_heat_2_7) <= +inf
-   0 <= flow(backpressure_bus_heat_2_8) <= +inf
    0 <= flow(backpressure_bus_el_0_0) <= +inf
    0 <= flow(backpressure_bus_el_0_1) <= +inf
    0 <= flow(backpressure_bus_el_0_2) <= +inf
@@ -353,10 +344,20 @@ bounds
    0 <= flow(backpressure_bus_el_2_6) <= +inf
    0 <= flow(backpressure_bus_el_2_7) <= +inf
    0 <= flow(backpressure_bus_el_2_8) <= +inf
+   0 <= flow(backpressure_bus_heat_0_0) <= +inf
+   0 <= flow(backpressure_bus_heat_0_1) <= +inf
+   0 <= flow(backpressure_bus_heat_0_2) <= +inf
+   0 <= flow(backpressure_bus_heat_1_3) <= +inf
+   0 <= flow(backpressure_bus_heat_1_4) <= +inf
+   0 <= flow(backpressure_bus_heat_1_5) <= +inf
+   0 <= flow(backpressure_bus_heat_2_6) <= +inf
+   0 <= flow(backpressure_bus_heat_2_7) <= +inf
+   0 <= flow(backpressure_bus_heat_2_8) <= +inf
    0 <= InvestmentFlowBlock_total(backpressure_bus_el_0) <= +inf
    0 <= InvestmentFlowBlock_total(backpressure_bus_el_1) <= +inf
-   0 <= InvestmentFlowBlock_old(backpressure_bus_el_1) <= +inf
    0 <= InvestmentFlowBlock_total(backpressure_bus_el_2) <= +inf
+   0 <= InvestmentFlowBlock_old(backpressure_bus_el_0) <= +inf
+   0 <= InvestmentFlowBlock_old(backpressure_bus_el_1) <= +inf
    0 <= InvestmentFlowBlock_old(backpressure_bus_el_2) <= +inf
    0 <= InvestmentFlowBlock_old_end(backpressure_bus_el_0) <= +inf
    0 <= InvestmentFlowBlock_old_end(backpressure_bus_el_1) <= +inf
@@ -364,5 +365,4 @@ bounds
    0 <= InvestmentFlowBlock_old_exo(backpressure_bus_el_0) <= +inf
    0 <= InvestmentFlowBlock_old_exo(backpressure_bus_el_1) <= +inf
    0 <= InvestmentFlowBlock_old_exo(backpressure_bus_el_2) <= +inf
-   0 <= InvestmentFlowBlock_old(backpressure_bus_el_0) <= +inf
 end

--- a/tests/_files/lp_files/multi-period/dispatchable_multi_period.lp
+++ b/tests/_files/lp_files/multi-period/dispatchable_multi_period.lp
@@ -3,9 +3,9 @@
 min 
 objective:
 +393187.4631175658 ONE_VAR_CONSTANT
-+561.5105784699618 InvestmentFlowBlock_invest(gt_electricity_0)
-+386.89361416194254 InvestmentFlowBlock_invest(gt_electricity_1)
-+267.76218567632424 InvestmentFlowBlock_invest(gt_electricity_2)
++550.3538603446715 InvestmentFlowBlock_invest(gt_electricity_0)
++226.09002140491177 InvestmentFlowBlock_invest(gt_electricity_1)
++15.604198638169356 InvestmentFlowBlock_invest(gt_electricity_2)
 +10 flow(gt_electricity_0_0)
 +10 flow(gt_electricity_0_1)
 +10 flow(gt_electricity_0_2)
@@ -99,9 +99,9 @@ c_e_InvestmentFlowBlock_old_rule_exo(gt_electricity_2)_:
 = 1000
 
 c_e_InvestmentFlowBlock_old_rule(gt_electricity_0)_:
++1 InvestmentFlowBlock_old(gt_electricity_0)
 -1 InvestmentFlowBlock_old_end(gt_electricity_0)
 -1 InvestmentFlowBlock_old_exo(gt_electricity_0)
-+1 InvestmentFlowBlock_old(gt_electricity_0)
 = 0
 
 c_e_InvestmentFlowBlock_old_rule(gt_electricity_1)_:
@@ -222,8 +222,9 @@ bounds
    0 <= flow(gt_electricity_2_8) <= +inf
    0 <= InvestmentFlowBlock_total(gt_electricity_0) <= +inf
    0 <= InvestmentFlowBlock_total(gt_electricity_1) <= +inf
-   0 <= InvestmentFlowBlock_old(gt_electricity_1) <= +inf
    0 <= InvestmentFlowBlock_total(gt_electricity_2) <= +inf
+   0 <= InvestmentFlowBlock_old(gt_electricity_0) <= +inf
+   0 <= InvestmentFlowBlock_old(gt_electricity_1) <= +inf
    0 <= InvestmentFlowBlock_old(gt_electricity_2) <= +inf
    0 <= InvestmentFlowBlock_old_end(gt_electricity_0) <= +inf
    0 <= InvestmentFlowBlock_old_end(gt_electricity_1) <= +inf
@@ -231,5 +232,4 @@ bounds
    0 <= InvestmentFlowBlock_old_exo(gt_electricity_0) <= +inf
    0 <= InvestmentFlowBlock_old_exo(gt_electricity_1) <= +inf
    0 <= InvestmentFlowBlock_old_exo(gt_electricity_2) <= +inf
-   0 <= InvestmentFlowBlock_old(gt_electricity_0) <= +inf
 end

--- a/tests/_files/lp_files/multi-period/extraction_investment_brown_field_multi_period.lp
+++ b/tests/_files/lp_files/multi-period/extraction_investment_brown_field_multi_period.lp
@@ -1,11 +1,11 @@
 \* Source Pyomo model name=Model *\
 
-min
+min 
 objective:
 +393187.4631175658 ONE_VAR_CONSTANT
-+561.5105784699618 InvestmentFlowBlock_invest(extraction_electricity_0)
-+386.89361416194254 InvestmentFlowBlock_invest(extraction_electricity_1)
-+267.76218567632424 InvestmentFlowBlock_invest(extraction_electricity_2)
++550.3538603446715 InvestmentFlowBlock_invest(extraction_electricity_0)
++226.09002140491177 InvestmentFlowBlock_invest(extraction_electricity_1)
++15.604198638169356 InvestmentFlowBlock_invest(extraction_electricity_2)
 +0.6 flow(gas_extraction_0_0)
 +0.6 flow(gas_extraction_0_1)
 +0.6 flow(gas_extraction_0_2)
@@ -18,40 +18,40 @@ objective:
 
 s.t.
 
-c_e_BusBlock_balance(heat_0_0)_:
-+1 flow(extraction_heat_0_0)
+c_e_BusBlock_balance(electricity_0_0)_:
++1 flow(extraction_electricity_0_0)
 = 0
 
-c_e_BusBlock_balance(heat_0_1)_:
-+1 flow(extraction_heat_0_1)
+c_e_BusBlock_balance(electricity_0_1)_:
++1 flow(extraction_electricity_0_1)
 = 0
 
-c_e_BusBlock_balance(heat_0_2)_:
-+1 flow(extraction_heat_0_2)
+c_e_BusBlock_balance(electricity_0_2)_:
++1 flow(extraction_electricity_0_2)
 = 0
 
-c_e_BusBlock_balance(heat_1_3)_:
-+1 flow(extraction_heat_1_3)
+c_e_BusBlock_balance(electricity_1_3)_:
++1 flow(extraction_electricity_1_3)
 = 0
 
-c_e_BusBlock_balance(heat_1_4)_:
-+1 flow(extraction_heat_1_4)
+c_e_BusBlock_balance(electricity_1_4)_:
++1 flow(extraction_electricity_1_4)
 = 0
 
-c_e_BusBlock_balance(heat_1_5)_:
-+1 flow(extraction_heat_1_5)
+c_e_BusBlock_balance(electricity_1_5)_:
++1 flow(extraction_electricity_1_5)
 = 0
 
-c_e_BusBlock_balance(heat_2_6)_:
-+1 flow(extraction_heat_2_6)
+c_e_BusBlock_balance(electricity_2_6)_:
++1 flow(extraction_electricity_2_6)
 = 0
 
-c_e_BusBlock_balance(heat_2_7)_:
-+1 flow(extraction_heat_2_7)
+c_e_BusBlock_balance(electricity_2_7)_:
++1 flow(extraction_electricity_2_7)
 = 0
 
-c_e_BusBlock_balance(heat_2_8)_:
-+1 flow(extraction_heat_2_8)
+c_e_BusBlock_balance(electricity_2_8)_:
++1 flow(extraction_electricity_2_8)
 = 0
 
 c_e_BusBlock_balance(gas_0_0)_:
@@ -90,40 +90,40 @@ c_e_BusBlock_balance(gas_2_8)_:
 +1 flow(gas_extraction_2_8)
 = 0
 
-c_e_BusBlock_balance(electricity_0_0)_:
-+1 flow(extraction_electricity_0_0)
+c_e_BusBlock_balance(heat_0_0)_:
++1 flow(extraction_heat_0_0)
 = 0
 
-c_e_BusBlock_balance(electricity_0_1)_:
-+1 flow(extraction_electricity_0_1)
+c_e_BusBlock_balance(heat_0_1)_:
++1 flow(extraction_heat_0_1)
 = 0
 
-c_e_BusBlock_balance(electricity_0_2)_:
-+1 flow(extraction_electricity_0_2)
+c_e_BusBlock_balance(heat_0_2)_:
++1 flow(extraction_heat_0_2)
 = 0
 
-c_e_BusBlock_balance(electricity_1_3)_:
-+1 flow(extraction_electricity_1_3)
+c_e_BusBlock_balance(heat_1_3)_:
++1 flow(extraction_heat_1_3)
 = 0
 
-c_e_BusBlock_balance(electricity_1_4)_:
-+1 flow(extraction_electricity_1_4)
+c_e_BusBlock_balance(heat_1_4)_:
++1 flow(extraction_heat_1_4)
 = 0
 
-c_e_BusBlock_balance(electricity_1_5)_:
-+1 flow(extraction_electricity_1_5)
+c_e_BusBlock_balance(heat_1_5)_:
++1 flow(extraction_heat_1_5)
 = 0
 
-c_e_BusBlock_balance(electricity_2_6)_:
-+1 flow(extraction_electricity_2_6)
+c_e_BusBlock_balance(heat_2_6)_:
++1 flow(extraction_heat_2_6)
 = 0
 
-c_e_BusBlock_balance(electricity_2_7)_:
-+1 flow(extraction_electricity_2_7)
+c_e_BusBlock_balance(heat_2_7)_:
++1 flow(extraction_heat_2_7)
 = 0
 
-c_e_BusBlock_balance(electricity_2_8)_:
-+1 flow(extraction_electricity_2_8)
+c_e_BusBlock_balance(heat_2_8)_:
++1 flow(extraction_heat_2_8)
 = 0
 
 c_e_InvestmentFlowBlock_total_rule(extraction_electricity_0)_:
@@ -171,9 +171,9 @@ c_e_InvestmentFlowBlock_old_rule_exo(extraction_electricity_2)_:
 = 1000
 
 c_e_InvestmentFlowBlock_old_rule(extraction_electricity_0)_:
++1 InvestmentFlowBlock_old(extraction_electricity_0)
 -1 InvestmentFlowBlock_old_end(extraction_electricity_0)
 -1 InvestmentFlowBlock_old_exo(extraction_electricity_0)
-+1 InvestmentFlowBlock_old(extraction_electricity_0)
 = 0
 
 c_e_InvestmentFlowBlock_old_rule(extraction_electricity_1)_:
@@ -235,101 +235,101 @@ c_u_InvestmentFlowBlock_max(extraction_electricity_2_8)_:
 
 c_e_ExtractionTurbineCHPBlock_input_output_relation(extraction_0_0)_:
 +1 flow(gas_extraction_0_0)
--0.5714285714285713 flow(extraction_heat_0_0)
 -2.0 flow(extraction_electricity_0_0)
+-0.5714285714285713 flow(extraction_heat_0_0)
 = 0
 
 c_e_ExtractionTurbineCHPBlock_input_output_relation(extraction_0_1)_:
 +1 flow(gas_extraction_0_1)
--0.5714285714285713 flow(extraction_heat_0_1)
 -2.0 flow(extraction_electricity_0_1)
+-0.5714285714285713 flow(extraction_heat_0_1)
 = 0
 
 c_e_ExtractionTurbineCHPBlock_input_output_relation(extraction_0_2)_:
 +1 flow(gas_extraction_0_2)
--0.5714285714285713 flow(extraction_heat_0_2)
 -2.0 flow(extraction_electricity_0_2)
+-0.5714285714285713 flow(extraction_heat_0_2)
 = 0
 
 c_e_ExtractionTurbineCHPBlock_input_output_relation(extraction_1_3)_:
 +1 flow(gas_extraction_1_3)
--0.5714285714285713 flow(extraction_heat_1_3)
 -2.0 flow(extraction_electricity_1_3)
+-0.5714285714285713 flow(extraction_heat_1_3)
 = 0
 
 c_e_ExtractionTurbineCHPBlock_input_output_relation(extraction_1_4)_:
 +1 flow(gas_extraction_1_4)
--0.5714285714285713 flow(extraction_heat_1_4)
 -2.0 flow(extraction_electricity_1_4)
+-0.5714285714285713 flow(extraction_heat_1_4)
 = 0
 
 c_e_ExtractionTurbineCHPBlock_input_output_relation(extraction_1_5)_:
 +1 flow(gas_extraction_1_5)
--0.5714285714285713 flow(extraction_heat_1_5)
 -2.0 flow(extraction_electricity_1_5)
+-0.5714285714285713 flow(extraction_heat_1_5)
 = 0
 
 c_e_ExtractionTurbineCHPBlock_input_output_relation(extraction_2_6)_:
 +1 flow(gas_extraction_2_6)
--0.5714285714285713 flow(extraction_heat_2_6)
 -2.0 flow(extraction_electricity_2_6)
+-0.5714285714285713 flow(extraction_heat_2_6)
 = 0
 
 c_e_ExtractionTurbineCHPBlock_input_output_relation(extraction_2_7)_:
 +1 flow(gas_extraction_2_7)
--0.5714285714285713 flow(extraction_heat_2_7)
 -2.0 flow(extraction_electricity_2_7)
+-0.5714285714285713 flow(extraction_heat_2_7)
 = 0
 
 c_e_ExtractionTurbineCHPBlock_input_output_relation(extraction_2_8)_:
 +1 flow(gas_extraction_2_8)
--0.5714285714285713 flow(extraction_heat_2_8)
 -2.0 flow(extraction_electricity_2_8)
+-0.5714285714285713 flow(extraction_heat_2_8)
 = 0
 
 c_u_ExtractionTurbineCHPBlock_out_flow_relation(extraction_0_0)_:
-+1.142857142857143 flow(extraction_heat_0_0)
 -1 flow(extraction_electricity_0_0)
++1.142857142857143 flow(extraction_heat_0_0)
 <= 0
 
 c_u_ExtractionTurbineCHPBlock_out_flow_relation(extraction_0_1)_:
-+1.142857142857143 flow(extraction_heat_0_1)
 -1 flow(extraction_electricity_0_1)
++1.142857142857143 flow(extraction_heat_0_1)
 <= 0
 
 c_u_ExtractionTurbineCHPBlock_out_flow_relation(extraction_0_2)_:
-+1.142857142857143 flow(extraction_heat_0_2)
 -1 flow(extraction_electricity_0_2)
++1.142857142857143 flow(extraction_heat_0_2)
 <= 0
 
 c_u_ExtractionTurbineCHPBlock_out_flow_relation(extraction_1_3)_:
-+1.142857142857143 flow(extraction_heat_1_3)
 -1 flow(extraction_electricity_1_3)
++1.142857142857143 flow(extraction_heat_1_3)
 <= 0
 
 c_u_ExtractionTurbineCHPBlock_out_flow_relation(extraction_1_4)_:
-+1.142857142857143 flow(extraction_heat_1_4)
 -1 flow(extraction_electricity_1_4)
++1.142857142857143 flow(extraction_heat_1_4)
 <= 0
 
 c_u_ExtractionTurbineCHPBlock_out_flow_relation(extraction_1_5)_:
-+1.142857142857143 flow(extraction_heat_1_5)
 -1 flow(extraction_electricity_1_5)
++1.142857142857143 flow(extraction_heat_1_5)
 <= 0
 
 c_u_ExtractionTurbineCHPBlock_out_flow_relation(extraction_2_6)_:
-+1.142857142857143 flow(extraction_heat_2_6)
 -1 flow(extraction_electricity_2_6)
++1.142857142857143 flow(extraction_heat_2_6)
 <= 0
 
 c_u_ExtractionTurbineCHPBlock_out_flow_relation(extraction_2_7)_:
-+1.142857142857143 flow(extraction_heat_2_7)
 -1 flow(extraction_electricity_2_7)
++1.142857142857143 flow(extraction_heat_2_7)
 <= 0
 
 c_u_ExtractionTurbineCHPBlock_out_flow_relation(extraction_2_8)_:
-+1.142857142857143 flow(extraction_heat_2_8)
 -1 flow(extraction_electricity_2_8)
++1.142857142857143 flow(extraction_heat_2_8)
 <= 0
 
 bounds
@@ -346,15 +346,6 @@ bounds
    0 <= flow(gas_extraction_2_6) <= +inf
    0 <= flow(gas_extraction_2_7) <= +inf
    0 <= flow(gas_extraction_2_8) <= +inf
-   0 <= flow(extraction_heat_0_0) <= +inf
-   0 <= flow(extraction_heat_0_1) <= +inf
-   0 <= flow(extraction_heat_0_2) <= +inf
-   0 <= flow(extraction_heat_1_3) <= +inf
-   0 <= flow(extraction_heat_1_4) <= +inf
-   0 <= flow(extraction_heat_1_5) <= +inf
-   0 <= flow(extraction_heat_2_6) <= +inf
-   0 <= flow(extraction_heat_2_7) <= +inf
-   0 <= flow(extraction_heat_2_8) <= +inf
    0 <= flow(extraction_electricity_0_0) <= +inf
    0 <= flow(extraction_electricity_0_1) <= +inf
    0 <= flow(extraction_electricity_0_2) <= +inf
@@ -364,10 +355,20 @@ bounds
    0 <= flow(extraction_electricity_2_6) <= +inf
    0 <= flow(extraction_electricity_2_7) <= +inf
    0 <= flow(extraction_electricity_2_8) <= +inf
+   0 <= flow(extraction_heat_0_0) <= +inf
+   0 <= flow(extraction_heat_0_1) <= +inf
+   0 <= flow(extraction_heat_0_2) <= +inf
+   0 <= flow(extraction_heat_1_3) <= +inf
+   0 <= flow(extraction_heat_1_4) <= +inf
+   0 <= flow(extraction_heat_1_5) <= +inf
+   0 <= flow(extraction_heat_2_6) <= +inf
+   0 <= flow(extraction_heat_2_7) <= +inf
+   0 <= flow(extraction_heat_2_8) <= +inf
    0 <= InvestmentFlowBlock_total(extraction_electricity_0) <= +inf
    0 <= InvestmentFlowBlock_total(extraction_electricity_1) <= +inf
-   0 <= InvestmentFlowBlock_old(extraction_electricity_1) <= +inf
    0 <= InvestmentFlowBlock_total(extraction_electricity_2) <= +inf
+   0 <= InvestmentFlowBlock_old(extraction_electricity_0) <= +inf
+   0 <= InvestmentFlowBlock_old(extraction_electricity_1) <= +inf
    0 <= InvestmentFlowBlock_old(extraction_electricity_2) <= +inf
    0 <= InvestmentFlowBlock_old_end(extraction_electricity_0) <= +inf
    0 <= InvestmentFlowBlock_old_end(extraction_electricity_1) <= +inf
@@ -375,5 +376,4 @@ bounds
    0 <= InvestmentFlowBlock_old_exo(extraction_electricity_0) <= +inf
    0 <= InvestmentFlowBlock_old_exo(extraction_electricity_1) <= +inf
    0 <= InvestmentFlowBlock_old_exo(extraction_electricity_2) <= +inf
-   0 <= InvestmentFlowBlock_old(extraction_electricity_0) <= +inf
 end

--- a/tests/_files/lp_files/multi-period/extraction_investment_green_field_multi_period.lp
+++ b/tests/_files/lp_files/multi-period/extraction_investment_green_field_multi_period.lp
@@ -1,10 +1,10 @@
 \* Source Pyomo model name=Model *\
 
-min
+min 
 objective:
-+561.5105784699618 InvestmentFlowBlock_invest(extraction_electricity_0)
-+386.89361416194254 InvestmentFlowBlock_invest(extraction_electricity_1)
-+267.76218567632424 InvestmentFlowBlock_invest(extraction_electricity_2)
++550.3538603446715 InvestmentFlowBlock_invest(extraction_electricity_0)
++226.09002140491177 InvestmentFlowBlock_invest(extraction_electricity_1)
++15.604198638169356 InvestmentFlowBlock_invest(extraction_electricity_2)
 +0.6 flow(gas_extraction_0_0)
 +0.6 flow(gas_extraction_0_1)
 +0.6 flow(gas_extraction_0_2)
@@ -17,40 +17,40 @@ objective:
 
 s.t.
 
-c_e_BusBlock_balance(heat_0_0)_:
-+1 flow(extraction_heat_0_0)
+c_e_BusBlock_balance(electricity_0_0)_:
++1 flow(extraction_electricity_0_0)
 = 0
 
-c_e_BusBlock_balance(heat_0_1)_:
-+1 flow(extraction_heat_0_1)
+c_e_BusBlock_balance(electricity_0_1)_:
++1 flow(extraction_electricity_0_1)
 = 0
 
-c_e_BusBlock_balance(heat_0_2)_:
-+1 flow(extraction_heat_0_2)
+c_e_BusBlock_balance(electricity_0_2)_:
++1 flow(extraction_electricity_0_2)
 = 0
 
-c_e_BusBlock_balance(heat_1_3)_:
-+1 flow(extraction_heat_1_3)
+c_e_BusBlock_balance(electricity_1_3)_:
++1 flow(extraction_electricity_1_3)
 = 0
 
-c_e_BusBlock_balance(heat_1_4)_:
-+1 flow(extraction_heat_1_4)
+c_e_BusBlock_balance(electricity_1_4)_:
++1 flow(extraction_electricity_1_4)
 = 0
 
-c_e_BusBlock_balance(heat_1_5)_:
-+1 flow(extraction_heat_1_5)
+c_e_BusBlock_balance(electricity_1_5)_:
++1 flow(extraction_electricity_1_5)
 = 0
 
-c_e_BusBlock_balance(heat_2_6)_:
-+1 flow(extraction_heat_2_6)
+c_e_BusBlock_balance(electricity_2_6)_:
++1 flow(extraction_electricity_2_6)
 = 0
 
-c_e_BusBlock_balance(heat_2_7)_:
-+1 flow(extraction_heat_2_7)
+c_e_BusBlock_balance(electricity_2_7)_:
++1 flow(extraction_electricity_2_7)
 = 0
 
-c_e_BusBlock_balance(heat_2_8)_:
-+1 flow(extraction_heat_2_8)
+c_e_BusBlock_balance(electricity_2_8)_:
++1 flow(extraction_electricity_2_8)
 = 0
 
 c_e_BusBlock_balance(gas_0_0)_:
@@ -89,40 +89,40 @@ c_e_BusBlock_balance(gas_2_8)_:
 +1 flow(gas_extraction_2_8)
 = 0
 
-c_e_BusBlock_balance(electricity_0_0)_:
-+1 flow(extraction_electricity_0_0)
+c_e_BusBlock_balance(heat_0_0)_:
++1 flow(extraction_heat_0_0)
 = 0
 
-c_e_BusBlock_balance(electricity_0_1)_:
-+1 flow(extraction_electricity_0_1)
+c_e_BusBlock_balance(heat_0_1)_:
++1 flow(extraction_heat_0_1)
 = 0
 
-c_e_BusBlock_balance(electricity_0_2)_:
-+1 flow(extraction_electricity_0_2)
+c_e_BusBlock_balance(heat_0_2)_:
++1 flow(extraction_heat_0_2)
 = 0
 
-c_e_BusBlock_balance(electricity_1_3)_:
-+1 flow(extraction_electricity_1_3)
+c_e_BusBlock_balance(heat_1_3)_:
++1 flow(extraction_heat_1_3)
 = 0
 
-c_e_BusBlock_balance(electricity_1_4)_:
-+1 flow(extraction_electricity_1_4)
+c_e_BusBlock_balance(heat_1_4)_:
++1 flow(extraction_heat_1_4)
 = 0
 
-c_e_BusBlock_balance(electricity_1_5)_:
-+1 flow(extraction_electricity_1_5)
+c_e_BusBlock_balance(heat_1_5)_:
++1 flow(extraction_heat_1_5)
 = 0
 
-c_e_BusBlock_balance(electricity_2_6)_:
-+1 flow(extraction_electricity_2_6)
+c_e_BusBlock_balance(heat_2_6)_:
++1 flow(extraction_heat_2_6)
 = 0
 
-c_e_BusBlock_balance(electricity_2_7)_:
-+1 flow(extraction_electricity_2_7)
+c_e_BusBlock_balance(heat_2_7)_:
++1 flow(extraction_heat_2_7)
 = 0
 
-c_e_BusBlock_balance(electricity_2_8)_:
-+1 flow(extraction_electricity_2_8)
+c_e_BusBlock_balance(heat_2_8)_:
++1 flow(extraction_heat_2_8)
 = 0
 
 c_e_InvestmentFlowBlock_total_rule(extraction_electricity_0)_:
@@ -170,9 +170,9 @@ c_e_InvestmentFlowBlock_old_rule_exo(extraction_electricity_2)_:
 = 0
 
 c_e_InvestmentFlowBlock_old_rule(extraction_electricity_0)_:
++1 InvestmentFlowBlock_old(extraction_electricity_0)
 -1 InvestmentFlowBlock_old_end(extraction_electricity_0)
 -1 InvestmentFlowBlock_old_exo(extraction_electricity_0)
-+1 InvestmentFlowBlock_old(extraction_electricity_0)
 = 0
 
 c_e_InvestmentFlowBlock_old_rule(extraction_electricity_1)_:
@@ -234,101 +234,101 @@ c_u_InvestmentFlowBlock_max(extraction_electricity_2_8)_:
 
 c_e_ExtractionTurbineCHPBlock_input_output_relation(extraction_0_0)_:
 +1 flow(gas_extraction_0_0)
--0.5714285714285713 flow(extraction_heat_0_0)
 -2.0 flow(extraction_electricity_0_0)
+-0.5714285714285713 flow(extraction_heat_0_0)
 = 0
 
 c_e_ExtractionTurbineCHPBlock_input_output_relation(extraction_0_1)_:
 +1 flow(gas_extraction_0_1)
--0.5714285714285713 flow(extraction_heat_0_1)
 -2.0 flow(extraction_electricity_0_1)
+-0.5714285714285713 flow(extraction_heat_0_1)
 = 0
 
 c_e_ExtractionTurbineCHPBlock_input_output_relation(extraction_0_2)_:
 +1 flow(gas_extraction_0_2)
--0.5714285714285713 flow(extraction_heat_0_2)
 -2.0 flow(extraction_electricity_0_2)
+-0.5714285714285713 flow(extraction_heat_0_2)
 = 0
 
 c_e_ExtractionTurbineCHPBlock_input_output_relation(extraction_1_3)_:
 +1 flow(gas_extraction_1_3)
--0.5714285714285713 flow(extraction_heat_1_3)
 -2.0 flow(extraction_electricity_1_3)
+-0.5714285714285713 flow(extraction_heat_1_3)
 = 0
 
 c_e_ExtractionTurbineCHPBlock_input_output_relation(extraction_1_4)_:
 +1 flow(gas_extraction_1_4)
--0.5714285714285713 flow(extraction_heat_1_4)
 -2.0 flow(extraction_electricity_1_4)
+-0.5714285714285713 flow(extraction_heat_1_4)
 = 0
 
 c_e_ExtractionTurbineCHPBlock_input_output_relation(extraction_1_5)_:
 +1 flow(gas_extraction_1_5)
--0.5714285714285713 flow(extraction_heat_1_5)
 -2.0 flow(extraction_electricity_1_5)
+-0.5714285714285713 flow(extraction_heat_1_5)
 = 0
 
 c_e_ExtractionTurbineCHPBlock_input_output_relation(extraction_2_6)_:
 +1 flow(gas_extraction_2_6)
--0.5714285714285713 flow(extraction_heat_2_6)
 -2.0 flow(extraction_electricity_2_6)
+-0.5714285714285713 flow(extraction_heat_2_6)
 = 0
 
 c_e_ExtractionTurbineCHPBlock_input_output_relation(extraction_2_7)_:
 +1 flow(gas_extraction_2_7)
--0.5714285714285713 flow(extraction_heat_2_7)
 -2.0 flow(extraction_electricity_2_7)
+-0.5714285714285713 flow(extraction_heat_2_7)
 = 0
 
 c_e_ExtractionTurbineCHPBlock_input_output_relation(extraction_2_8)_:
 +1 flow(gas_extraction_2_8)
--0.5714285714285713 flow(extraction_heat_2_8)
 -2.0 flow(extraction_electricity_2_8)
+-0.5714285714285713 flow(extraction_heat_2_8)
 = 0
 
 c_u_ExtractionTurbineCHPBlock_out_flow_relation(extraction_0_0)_:
-+1.142857142857143 flow(extraction_heat_0_0)
 -1 flow(extraction_electricity_0_0)
++1.142857142857143 flow(extraction_heat_0_0)
 <= 0
 
 c_u_ExtractionTurbineCHPBlock_out_flow_relation(extraction_0_1)_:
-+1.142857142857143 flow(extraction_heat_0_1)
 -1 flow(extraction_electricity_0_1)
++1.142857142857143 flow(extraction_heat_0_1)
 <= 0
 
 c_u_ExtractionTurbineCHPBlock_out_flow_relation(extraction_0_2)_:
-+1.142857142857143 flow(extraction_heat_0_2)
 -1 flow(extraction_electricity_0_2)
++1.142857142857143 flow(extraction_heat_0_2)
 <= 0
 
 c_u_ExtractionTurbineCHPBlock_out_flow_relation(extraction_1_3)_:
-+1.142857142857143 flow(extraction_heat_1_3)
 -1 flow(extraction_electricity_1_3)
++1.142857142857143 flow(extraction_heat_1_3)
 <= 0
 
 c_u_ExtractionTurbineCHPBlock_out_flow_relation(extraction_1_4)_:
-+1.142857142857143 flow(extraction_heat_1_4)
 -1 flow(extraction_electricity_1_4)
++1.142857142857143 flow(extraction_heat_1_4)
 <= 0
 
 c_u_ExtractionTurbineCHPBlock_out_flow_relation(extraction_1_5)_:
-+1.142857142857143 flow(extraction_heat_1_5)
 -1 flow(extraction_electricity_1_5)
++1.142857142857143 flow(extraction_heat_1_5)
 <= 0
 
 c_u_ExtractionTurbineCHPBlock_out_flow_relation(extraction_2_6)_:
-+1.142857142857143 flow(extraction_heat_2_6)
 -1 flow(extraction_electricity_2_6)
++1.142857142857143 flow(extraction_heat_2_6)
 <= 0
 
 c_u_ExtractionTurbineCHPBlock_out_flow_relation(extraction_2_7)_:
-+1.142857142857143 flow(extraction_heat_2_7)
 -1 flow(extraction_electricity_2_7)
++1.142857142857143 flow(extraction_heat_2_7)
 <= 0
 
 c_u_ExtractionTurbineCHPBlock_out_flow_relation(extraction_2_8)_:
-+1.142857142857143 flow(extraction_heat_2_8)
 -1 flow(extraction_electricity_2_8)
++1.142857142857143 flow(extraction_heat_2_8)
 <= 0
 
 bounds
@@ -344,15 +344,6 @@ bounds
    0 <= flow(gas_extraction_2_6) <= +inf
    0 <= flow(gas_extraction_2_7) <= +inf
    0 <= flow(gas_extraction_2_8) <= +inf
-   0 <= flow(extraction_heat_0_0) <= +inf
-   0 <= flow(extraction_heat_0_1) <= +inf
-   0 <= flow(extraction_heat_0_2) <= +inf
-   0 <= flow(extraction_heat_1_3) <= +inf
-   0 <= flow(extraction_heat_1_4) <= +inf
-   0 <= flow(extraction_heat_1_5) <= +inf
-   0 <= flow(extraction_heat_2_6) <= +inf
-   0 <= flow(extraction_heat_2_7) <= +inf
-   0 <= flow(extraction_heat_2_8) <= +inf
    0 <= flow(extraction_electricity_0_0) <= +inf
    0 <= flow(extraction_electricity_0_1) <= +inf
    0 <= flow(extraction_electricity_0_2) <= +inf
@@ -362,10 +353,20 @@ bounds
    0 <= flow(extraction_electricity_2_6) <= +inf
    0 <= flow(extraction_electricity_2_7) <= +inf
    0 <= flow(extraction_electricity_2_8) <= +inf
+   0 <= flow(extraction_heat_0_0) <= +inf
+   0 <= flow(extraction_heat_0_1) <= +inf
+   0 <= flow(extraction_heat_0_2) <= +inf
+   0 <= flow(extraction_heat_1_3) <= +inf
+   0 <= flow(extraction_heat_1_4) <= +inf
+   0 <= flow(extraction_heat_1_5) <= +inf
+   0 <= flow(extraction_heat_2_6) <= +inf
+   0 <= flow(extraction_heat_2_7) <= +inf
+   0 <= flow(extraction_heat_2_8) <= +inf
    0 <= InvestmentFlowBlock_total(extraction_electricity_0) <= +inf
    0 <= InvestmentFlowBlock_total(extraction_electricity_1) <= +inf
-   0 <= InvestmentFlowBlock_old(extraction_electricity_1) <= +inf
    0 <= InvestmentFlowBlock_total(extraction_electricity_2) <= +inf
+   0 <= InvestmentFlowBlock_old(extraction_electricity_0) <= +inf
+   0 <= InvestmentFlowBlock_old(extraction_electricity_1) <= +inf
    0 <= InvestmentFlowBlock_old(extraction_electricity_2) <= +inf
    0 <= InvestmentFlowBlock_old_end(extraction_electricity_0) <= +inf
    0 <= InvestmentFlowBlock_old_end(extraction_electricity_1) <= +inf
@@ -373,5 +374,4 @@ bounds
    0 <= InvestmentFlowBlock_old_exo(extraction_electricity_0) <= +inf
    0 <= InvestmentFlowBlock_old_exo(extraction_electricity_1) <= +inf
    0 <= InvestmentFlowBlock_old_exo(extraction_electricity_2) <= +inf
-   0 <= InvestmentFlowBlock_old(extraction_electricity_0) <= +inf
 end

--- a/tests/_files/lp_files/multi-period/storage_investment_brown_field_multi_period.lp
+++ b/tests/_files/lp_files/multi-period/storage_investment_brown_field_multi_period.lp
@@ -1,60 +1,60 @@
 \* Source Pyomo model name=Model *\
 
-min
+min 
 objective:
 +1179.5623893526972 ONE_VAR_CONSTANT
-+793.9061073460653 InvestmentFlowBlock_invest(bus_el_storage_0)
-+577.5388911740415 InvestmentFlowBlock_invest(bus_el_storage_1)
-+424.1577145524276 InvestmentFlowBlock_invest(bus_el_storage_2)
-+2090.42853160222 GenericInvestmentStorageBlock_invest(storage_0)
-+1641.138857662593 GenericInvestmentStorageBlock_invest(storage_1)
-+1296.6801388085826 GenericInvestmentStorageBlock_invest(storage_2)
++740.3538603446715 InvestmentFlowBlock_invest(bus_el_storage_0)
++319.3808392388273 InvestmentFlowBlock_invest(bus_el_storage_1)
++23.270646132095994 InvestmentFlowBlock_invest(bus_el_storage_2)
++1800.3538603446716 GenericInvestmentStorageBlock_invest(storage_0)
++839.8454018911981 GenericInvestmentStorageBlock_invest(storage_1)
++66.04135320347618 GenericInvestmentStorageBlock_invest(storage_2)
 
 s.t.
 
 c_e_BusBlock_balance(bus_el_0_0)_:
-+1 flow(storage_bus_el_0_0)
 -1 flow(bus_el_storage_0_0)
++1 flow(storage_bus_el_0_0)
 = 0
 
 c_e_BusBlock_balance(bus_el_0_1)_:
-+1 flow(storage_bus_el_0_1)
 -1 flow(bus_el_storage_0_1)
++1 flow(storage_bus_el_0_1)
 = 0
 
 c_e_BusBlock_balance(bus_el_0_2)_:
-+1 flow(storage_bus_el_0_2)
 -1 flow(bus_el_storage_0_2)
++1 flow(storage_bus_el_0_2)
 = 0
 
 c_e_BusBlock_balance(bus_el_1_3)_:
-+1 flow(storage_bus_el_1_3)
 -1 flow(bus_el_storage_1_3)
++1 flow(storage_bus_el_1_3)
 = 0
 
 c_e_BusBlock_balance(bus_el_1_4)_:
-+1 flow(storage_bus_el_1_4)
 -1 flow(bus_el_storage_1_4)
++1 flow(storage_bus_el_1_4)
 = 0
 
 c_e_BusBlock_balance(bus_el_1_5)_:
-+1 flow(storage_bus_el_1_5)
 -1 flow(bus_el_storage_1_5)
++1 flow(storage_bus_el_1_5)
 = 0
 
 c_e_BusBlock_balance(bus_el_2_6)_:
-+1 flow(storage_bus_el_2_6)
 -1 flow(bus_el_storage_2_6)
++1 flow(storage_bus_el_2_6)
 = 0
 
 c_e_BusBlock_balance(bus_el_2_7)_:
-+1 flow(storage_bus_el_2_7)
 -1 flow(bus_el_storage_2_7)
++1 flow(storage_bus_el_2_7)
 = 0
 
 c_e_BusBlock_balance(bus_el_2_8)_:
-+1 flow(storage_bus_el_2_8)
 -1 flow(bus_el_storage_2_8)
++1 flow(storage_bus_el_2_8)
 = 0
 
 c_e_InvestmentFlowBlock_total_rule(bus_el_storage_0)_:
@@ -77,21 +77,21 @@ c_e_InvestmentFlowBlock_total_rule(bus_el_storage_2)_:
 = 0
 
 c_e_InvestmentFlowBlock_total_rule(storage_bus_el_0)_:
-+1 InvestmentFlowBlock_total(storage_bus_el_0)
 -1 InvestmentFlowBlock_invest(storage_bus_el_0)
++1 InvestmentFlowBlock_total(storage_bus_el_0)
 = 1
 
 c_e_InvestmentFlowBlock_total_rule(storage_bus_el_1)_:
+-1 InvestmentFlowBlock_invest(storage_bus_el_1)
 -1 InvestmentFlowBlock_total(storage_bus_el_0)
 +1 InvestmentFlowBlock_total(storage_bus_el_1)
--1 InvestmentFlowBlock_invest(storage_bus_el_1)
 +1 InvestmentFlowBlock_old(storage_bus_el_1)
 = 0
 
 c_e_InvestmentFlowBlock_total_rule(storage_bus_el_2)_:
+-1 InvestmentFlowBlock_invest(storage_bus_el_2)
 -1 InvestmentFlowBlock_total(storage_bus_el_1)
 +1 InvestmentFlowBlock_total(storage_bus_el_2)
--1 InvestmentFlowBlock_invest(storage_bus_el_2)
 +1 InvestmentFlowBlock_old(storage_bus_el_2)
 = 0
 
@@ -146,9 +146,9 @@ c_e_InvestmentFlowBlock_old_rule_exo(storage_bus_el_2)_:
 = 1
 
 c_e_InvestmentFlowBlock_old_rule(bus_el_storage_0)_:
++1 InvestmentFlowBlock_old(bus_el_storage_0)
 -1 InvestmentFlowBlock_old_end(bus_el_storage_0)
 -1 InvestmentFlowBlock_old_exo(bus_el_storage_0)
-+1 InvestmentFlowBlock_old(bus_el_storage_0)
 = 0
 
 c_e_InvestmentFlowBlock_old_rule(bus_el_storage_1)_:
@@ -164,9 +164,9 @@ c_e_InvestmentFlowBlock_old_rule(bus_el_storage_2)_:
 = 0
 
 c_e_InvestmentFlowBlock_old_rule(storage_bus_el_0)_:
++1 InvestmentFlowBlock_old(storage_bus_el_0)
 -1 InvestmentFlowBlock_old_end(storage_bus_el_0)
 -1 InvestmentFlowBlock_old_exo(storage_bus_el_0)
-+1 InvestmentFlowBlock_old(storage_bus_el_0)
 = 0
 
 c_e_InvestmentFlowBlock_old_rule(storage_bus_el_1)_:
@@ -316,9 +316,9 @@ c_e_GenericInvestmentStorageBlock_old_rule_exo(storage_2)_:
 = 2
 
 c_e_GenericInvestmentStorageBlock_old_rule(storage_0)_:
++1 GenericInvestmentStorageBlock_old(storage_0)
 -1 GenericInvestmentStorageBlock_old_end(storage_0)
 -1 GenericInvestmentStorageBlock_old_exo(storage_0)
-+1 GenericInvestmentStorageBlock_old(storage_0)
 = 0
 
 c_e_GenericInvestmentStorageBlock_old_rule(storage_1)_:
@@ -338,57 +338,57 @@ c_e_GenericInvestmentStorageBlock_initially_empty(storage_0)_:
 = 0
 
 c_e_GenericInvestmentStorageBlock_balance(storage_0_1)_:
-+1.1111111111111112 flow(storage_bus_el_0_1)
 -0.9 flow(bus_el_storage_0_1)
-+1 GenericInvestmentStorageBlock_storage_content(storage_1)
++1.1111111111111112 flow(storage_bus_el_0_1)
 -1 GenericInvestmentStorageBlock_storage_content(storage_0)
++1 GenericInvestmentStorageBlock_storage_content(storage_1)
 = 0
 
 c_e_GenericInvestmentStorageBlock_balance(storage_0_2)_:
-+1.1111111111111112 flow(storage_bus_el_0_2)
 -0.9 flow(bus_el_storage_0_2)
++1.1111111111111112 flow(storage_bus_el_0_2)
 -1 GenericInvestmentStorageBlock_storage_content(storage_1)
 +1 GenericInvestmentStorageBlock_storage_content(storage_2)
 = 0
 
 c_e_GenericInvestmentStorageBlock_balance(storage_1_3)_:
-+1.1111111111111112 flow(storage_bus_el_1_3)
 -0.9 flow(bus_el_storage_1_3)
++1.1111111111111112 flow(storage_bus_el_1_3)
 -1 GenericInvestmentStorageBlock_storage_content(storage_2)
 +1 GenericInvestmentStorageBlock_storage_content(storage_3)
 = 0
 
 c_e_GenericInvestmentStorageBlock_balance(storage_1_4)_:
-+1.1111111111111112 flow(storage_bus_el_1_4)
 -0.9 flow(bus_el_storage_1_4)
++1.1111111111111112 flow(storage_bus_el_1_4)
 -1 GenericInvestmentStorageBlock_storage_content(storage_3)
 +1 GenericInvestmentStorageBlock_storage_content(storage_4)
 = 0
 
 c_e_GenericInvestmentStorageBlock_balance(storage_1_5)_:
-+1.1111111111111112 flow(storage_bus_el_1_5)
 -0.9 flow(bus_el_storage_1_5)
++1.1111111111111112 flow(storage_bus_el_1_5)
 -1 GenericInvestmentStorageBlock_storage_content(storage_4)
 +1 GenericInvestmentStorageBlock_storage_content(storage_5)
 = 0
 
 c_e_GenericInvestmentStorageBlock_balance(storage_2_6)_:
-+1.1111111111111112 flow(storage_bus_el_2_6)
 -0.9 flow(bus_el_storage_2_6)
++1.1111111111111112 flow(storage_bus_el_2_6)
 -1 GenericInvestmentStorageBlock_storage_content(storage_5)
 +1 GenericInvestmentStorageBlock_storage_content(storage_6)
 = 0
 
 c_e_GenericInvestmentStorageBlock_balance(storage_2_7)_:
-+1.1111111111111112 flow(storage_bus_el_2_7)
 -0.9 flow(bus_el_storage_2_7)
++1.1111111111111112 flow(storage_bus_el_2_7)
 -1 GenericInvestmentStorageBlock_storage_content(storage_6)
 +1 GenericInvestmentStorageBlock_storage_content(storage_7)
 = 0
 
 c_e_GenericInvestmentStorageBlock_balance(storage_2_8)_:
-+1.1111111111111112 flow(storage_bus_el_2_8)
 -0.9 flow(bus_el_storage_2_8)
++1.1111111111111112 flow(storage_bus_el_2_8)
 -1 GenericInvestmentStorageBlock_storage_content(storage_7)
 +1 GenericInvestmentStorageBlock_storage_content(storage_8)
 = 0
@@ -458,39 +458,41 @@ bounds
    0 <= InvestmentFlowBlock_invest(bus_el_storage_0) <= 4
    0 <= InvestmentFlowBlock_invest(bus_el_storage_1) <= 4
    0 <= InvestmentFlowBlock_invest(bus_el_storage_2) <= 4
+   0 <= InvestmentFlowBlock_invest(storage_bus_el_0) <= +inf
+   0 <= InvestmentFlowBlock_invest(storage_bus_el_1) <= +inf
+   0 <= InvestmentFlowBlock_invest(storage_bus_el_2) <= +inf
    0 <= GenericInvestmentStorageBlock_invest(storage_0) <= 8
    0 <= GenericInvestmentStorageBlock_invest(storage_1) <= 8
    0 <= GenericInvestmentStorageBlock_invest(storage_2) <= 8
-   0 <= flow(storage_bus_el_0_0) <= +inf
    0 <= flow(bus_el_storage_0_0) <= +inf
-   0 <= flow(storage_bus_el_0_1) <= +inf
    0 <= flow(bus_el_storage_0_1) <= +inf
-   0 <= flow(storage_bus_el_0_2) <= +inf
    0 <= flow(bus_el_storage_0_2) <= +inf
-   0 <= flow(storage_bus_el_1_3) <= +inf
    0 <= flow(bus_el_storage_1_3) <= +inf
-   0 <= flow(storage_bus_el_1_4) <= +inf
    0 <= flow(bus_el_storage_1_4) <= +inf
-   0 <= flow(storage_bus_el_1_5) <= +inf
    0 <= flow(bus_el_storage_1_5) <= +inf
-   0 <= flow(storage_bus_el_2_6) <= +inf
    0 <= flow(bus_el_storage_2_6) <= +inf
-   0 <= flow(storage_bus_el_2_7) <= +inf
    0 <= flow(bus_el_storage_2_7) <= +inf
-   0 <= flow(storage_bus_el_2_8) <= +inf
    0 <= flow(bus_el_storage_2_8) <= +inf
+   0 <= flow(storage_bus_el_0_0) <= +inf
+   0 <= flow(storage_bus_el_0_1) <= +inf
+   0 <= flow(storage_bus_el_0_2) <= +inf
+   0 <= flow(storage_bus_el_1_3) <= +inf
+   0 <= flow(storage_bus_el_1_4) <= +inf
+   0 <= flow(storage_bus_el_1_5) <= +inf
+   0 <= flow(storage_bus_el_2_6) <= +inf
+   0 <= flow(storage_bus_el_2_7) <= +inf
+   0 <= flow(storage_bus_el_2_8) <= +inf
    0 <= InvestmentFlowBlock_total(bus_el_storage_0) <= +inf
    0 <= InvestmentFlowBlock_total(bus_el_storage_1) <= +inf
-   0 <= InvestmentFlowBlock_old(bus_el_storage_1) <= +inf
    0 <= InvestmentFlowBlock_total(bus_el_storage_2) <= +inf
-   0 <= InvestmentFlowBlock_old(bus_el_storage_2) <= +inf
    0 <= InvestmentFlowBlock_total(storage_bus_el_0) <= +inf
-   0 <= InvestmentFlowBlock_invest(storage_bus_el_0) <= +inf
    0 <= InvestmentFlowBlock_total(storage_bus_el_1) <= +inf
-   0 <= InvestmentFlowBlock_invest(storage_bus_el_1) <= +inf
-   0 <= InvestmentFlowBlock_old(storage_bus_el_1) <= +inf
    0 <= InvestmentFlowBlock_total(storage_bus_el_2) <= +inf
-   0 <= InvestmentFlowBlock_invest(storage_bus_el_2) <= +inf
+   0 <= InvestmentFlowBlock_old(bus_el_storage_0) <= +inf
+   0 <= InvestmentFlowBlock_old(bus_el_storage_1) <= +inf
+   0 <= InvestmentFlowBlock_old(bus_el_storage_2) <= +inf
+   0 <= InvestmentFlowBlock_old(storage_bus_el_0) <= +inf
+   0 <= InvestmentFlowBlock_old(storage_bus_el_1) <= +inf
    0 <= InvestmentFlowBlock_old(storage_bus_el_2) <= +inf
    0 <= InvestmentFlowBlock_old_end(bus_el_storage_0) <= +inf
    0 <= InvestmentFlowBlock_old_end(bus_el_storage_1) <= +inf
@@ -504,12 +506,11 @@ bounds
    0 <= InvestmentFlowBlock_old_exo(storage_bus_el_0) <= +inf
    0 <= InvestmentFlowBlock_old_exo(storage_bus_el_1) <= +inf
    0 <= InvestmentFlowBlock_old_exo(storage_bus_el_2) <= +inf
-   0 <= InvestmentFlowBlock_old(bus_el_storage_0) <= +inf
-   0 <= InvestmentFlowBlock_old(storage_bus_el_0) <= +inf
    0 <= GenericInvestmentStorageBlock_total(storage_0) <= +inf
    0 <= GenericInvestmentStorageBlock_total(storage_1) <= +inf
-   0 <= GenericInvestmentStorageBlock_old(storage_1) <= +inf
    0 <= GenericInvestmentStorageBlock_total(storage_2) <= +inf
+   0 <= GenericInvestmentStorageBlock_old(storage_0) <= +inf
+   0 <= GenericInvestmentStorageBlock_old(storage_1) <= +inf
    0 <= GenericInvestmentStorageBlock_old(storage_2) <= +inf
    0 <= GenericInvestmentStorageBlock_old_end(storage_0) <= +inf
    0 <= GenericInvestmentStorageBlock_old_end(storage_1) <= +inf
@@ -517,9 +518,8 @@ bounds
    0 <= GenericInvestmentStorageBlock_old_exo(storage_0) <= +inf
    0 <= GenericInvestmentStorageBlock_old_exo(storage_1) <= +inf
    0 <= GenericInvestmentStorageBlock_old_exo(storage_2) <= +inf
-   0 <= GenericInvestmentStorageBlock_old(storage_0) <= +inf
-   0 <= GenericInvestmentStorageBlock_storage_content(storage_1) <= +inf
    0 <= GenericInvestmentStorageBlock_storage_content(storage_0) <= +inf
+   0 <= GenericInvestmentStorageBlock_storage_content(storage_1) <= +inf
    0 <= GenericInvestmentStorageBlock_storage_content(storage_2) <= +inf
    0 <= GenericInvestmentStorageBlock_storage_content(storage_3) <= +inf
    0 <= GenericInvestmentStorageBlock_storage_content(storage_4) <= +inf

--- a/tests/_files/lp_files/multi-period/storage_investment_brown_field_no_storage_capacity_cost_multi_period.lp
+++ b/tests/_files/lp_files/multi-period/storage_investment_brown_field_no_storage_capacity_cost_multi_period.lp
@@ -1,60 +1,60 @@
 \* Source Pyomo model name=Model *\
 
-min
+min 
 objective:
 +1179.5623893526972 ONE_VAR_CONSTANT
-+793.9061073460653 InvestmentFlowBlock_invest(bus_el_storage_0)
-+577.5388911740415 InvestmentFlowBlock_invest(bus_el_storage_1)
-+424.1577145524276 InvestmentFlowBlock_invest(bus_el_storage_2)
++740.3538603446715 InvestmentFlowBlock_invest(bus_el_storage_0)
++319.3808392388273 InvestmentFlowBlock_invest(bus_el_storage_1)
++23.270646132095994 InvestmentFlowBlock_invest(bus_el_storage_2)
 +500.35386034467155 GenericInvestmentStorageBlock_invest(storage_0)
-+336.72380442191655 GenericInvestmentStorageBlock_invest(storage_1)
-+226.6054675510339 GenericInvestmentStorageBlock_invest(storage_2)
++201.53980618546032 GenericInvestmentStorageBlock_invest(storage_1)
++13.586712455557082 GenericInvestmentStorageBlock_invest(storage_2)
 
 s.t.
 
 c_e_BusBlock_balance(bus_el_0_0)_:
-+1 flow(storage_bus_el_0_0)
 -1 flow(bus_el_storage_0_0)
++1 flow(storage_bus_el_0_0)
 = 0
 
 c_e_BusBlock_balance(bus_el_0_1)_:
-+1 flow(storage_bus_el_0_1)
 -1 flow(bus_el_storage_0_1)
++1 flow(storage_bus_el_0_1)
 = 0
 
 c_e_BusBlock_balance(bus_el_0_2)_:
-+1 flow(storage_bus_el_0_2)
 -1 flow(bus_el_storage_0_2)
++1 flow(storage_bus_el_0_2)
 = 0
 
 c_e_BusBlock_balance(bus_el_1_3)_:
-+1 flow(storage_bus_el_1_3)
 -1 flow(bus_el_storage_1_3)
++1 flow(storage_bus_el_1_3)
 = 0
 
 c_e_BusBlock_balance(bus_el_1_4)_:
-+1 flow(storage_bus_el_1_4)
 -1 flow(bus_el_storage_1_4)
++1 flow(storage_bus_el_1_4)
 = 0
 
 c_e_BusBlock_balance(bus_el_1_5)_:
-+1 flow(storage_bus_el_1_5)
 -1 flow(bus_el_storage_1_5)
++1 flow(storage_bus_el_1_5)
 = 0
 
 c_e_BusBlock_balance(bus_el_2_6)_:
-+1 flow(storage_bus_el_2_6)
 -1 flow(bus_el_storage_2_6)
++1 flow(storage_bus_el_2_6)
 = 0
 
 c_e_BusBlock_balance(bus_el_2_7)_:
-+1 flow(storage_bus_el_2_7)
 -1 flow(bus_el_storage_2_7)
++1 flow(storage_bus_el_2_7)
 = 0
 
 c_e_BusBlock_balance(bus_el_2_8)_:
-+1 flow(storage_bus_el_2_8)
 -1 flow(bus_el_storage_2_8)
++1 flow(storage_bus_el_2_8)
 = 0
 
 c_e_InvestmentFlowBlock_total_rule(bus_el_storage_0)_:
@@ -77,21 +77,21 @@ c_e_InvestmentFlowBlock_total_rule(bus_el_storage_2)_:
 = 0
 
 c_e_InvestmentFlowBlock_total_rule(storage_bus_el_0)_:
-+1 InvestmentFlowBlock_total(storage_bus_el_0)
 -1 InvestmentFlowBlock_invest(storage_bus_el_0)
++1 InvestmentFlowBlock_total(storage_bus_el_0)
 = 1
 
 c_e_InvestmentFlowBlock_total_rule(storage_bus_el_1)_:
+-1 InvestmentFlowBlock_invest(storage_bus_el_1)
 -1 InvestmentFlowBlock_total(storage_bus_el_0)
 +1 InvestmentFlowBlock_total(storage_bus_el_1)
--1 InvestmentFlowBlock_invest(storage_bus_el_1)
 +1 InvestmentFlowBlock_old(storage_bus_el_1)
 = 0
 
 c_e_InvestmentFlowBlock_total_rule(storage_bus_el_2)_:
+-1 InvestmentFlowBlock_invest(storage_bus_el_2)
 -1 InvestmentFlowBlock_total(storage_bus_el_1)
 +1 InvestmentFlowBlock_total(storage_bus_el_2)
--1 InvestmentFlowBlock_invest(storage_bus_el_2)
 +1 InvestmentFlowBlock_old(storage_bus_el_2)
 = 0
 
@@ -146,9 +146,9 @@ c_e_InvestmentFlowBlock_old_rule_exo(storage_bus_el_2)_:
 = 1
 
 c_e_InvestmentFlowBlock_old_rule(bus_el_storage_0)_:
++1 InvestmentFlowBlock_old(bus_el_storage_0)
 -1 InvestmentFlowBlock_old_end(bus_el_storage_0)
 -1 InvestmentFlowBlock_old_exo(bus_el_storage_0)
-+1 InvestmentFlowBlock_old(bus_el_storage_0)
 = 0
 
 c_e_InvestmentFlowBlock_old_rule(bus_el_storage_1)_:
@@ -164,9 +164,9 @@ c_e_InvestmentFlowBlock_old_rule(bus_el_storage_2)_:
 = 0
 
 c_e_InvestmentFlowBlock_old_rule(storage_bus_el_0)_:
++1 InvestmentFlowBlock_old(storage_bus_el_0)
 -1 InvestmentFlowBlock_old_end(storage_bus_el_0)
 -1 InvestmentFlowBlock_old_exo(storage_bus_el_0)
-+1 InvestmentFlowBlock_old(storage_bus_el_0)
 = 0
 
 c_e_InvestmentFlowBlock_old_rule(storage_bus_el_1)_:
@@ -316,9 +316,9 @@ c_e_GenericInvestmentStorageBlock_old_rule_exo(storage_2)_:
 = 2
 
 c_e_GenericInvestmentStorageBlock_old_rule(storage_0)_:
++1 GenericInvestmentStorageBlock_old(storage_0)
 -1 GenericInvestmentStorageBlock_old_end(storage_0)
 -1 GenericInvestmentStorageBlock_old_exo(storage_0)
-+1 GenericInvestmentStorageBlock_old(storage_0)
 = 0
 
 c_e_GenericInvestmentStorageBlock_old_rule(storage_1)_:
@@ -338,57 +338,57 @@ c_e_GenericInvestmentStorageBlock_initially_empty(storage_0)_:
 = 0
 
 c_e_GenericInvestmentStorageBlock_balance(storage_0_1)_:
-+1.1111111111111112 flow(storage_bus_el_0_1)
 -0.9 flow(bus_el_storage_0_1)
-+1 GenericInvestmentStorageBlock_storage_content(storage_1)
++1.1111111111111112 flow(storage_bus_el_0_1)
 -1 GenericInvestmentStorageBlock_storage_content(storage_0)
++1 GenericInvestmentStorageBlock_storage_content(storage_1)
 = 0
 
 c_e_GenericInvestmentStorageBlock_balance(storage_0_2)_:
-+1.1111111111111112 flow(storage_bus_el_0_2)
 -0.9 flow(bus_el_storage_0_2)
++1.1111111111111112 flow(storage_bus_el_0_2)
 -1 GenericInvestmentStorageBlock_storage_content(storage_1)
 +1 GenericInvestmentStorageBlock_storage_content(storage_2)
 = 0
 
 c_e_GenericInvestmentStorageBlock_balance(storage_1_3)_:
-+1.1111111111111112 flow(storage_bus_el_1_3)
 -0.9 flow(bus_el_storage_1_3)
++1.1111111111111112 flow(storage_bus_el_1_3)
 -1 GenericInvestmentStorageBlock_storage_content(storage_2)
 +1 GenericInvestmentStorageBlock_storage_content(storage_3)
 = 0
 
 c_e_GenericInvestmentStorageBlock_balance(storage_1_4)_:
-+1.1111111111111112 flow(storage_bus_el_1_4)
 -0.9 flow(bus_el_storage_1_4)
++1.1111111111111112 flow(storage_bus_el_1_4)
 -1 GenericInvestmentStorageBlock_storage_content(storage_3)
 +1 GenericInvestmentStorageBlock_storage_content(storage_4)
 = 0
 
 c_e_GenericInvestmentStorageBlock_balance(storage_1_5)_:
-+1.1111111111111112 flow(storage_bus_el_1_5)
 -0.9 flow(bus_el_storage_1_5)
++1.1111111111111112 flow(storage_bus_el_1_5)
 -1 GenericInvestmentStorageBlock_storage_content(storage_4)
 +1 GenericInvestmentStorageBlock_storage_content(storage_5)
 = 0
 
 c_e_GenericInvestmentStorageBlock_balance(storage_2_6)_:
-+1.1111111111111112 flow(storage_bus_el_2_6)
 -0.9 flow(bus_el_storage_2_6)
++1.1111111111111112 flow(storage_bus_el_2_6)
 -1 GenericInvestmentStorageBlock_storage_content(storage_5)
 +1 GenericInvestmentStorageBlock_storage_content(storage_6)
 = 0
 
 c_e_GenericInvestmentStorageBlock_balance(storage_2_7)_:
-+1.1111111111111112 flow(storage_bus_el_2_7)
 -0.9 flow(bus_el_storage_2_7)
++1.1111111111111112 flow(storage_bus_el_2_7)
 -1 GenericInvestmentStorageBlock_storage_content(storage_6)
 +1 GenericInvestmentStorageBlock_storage_content(storage_7)
 = 0
 
 c_e_GenericInvestmentStorageBlock_balance(storage_2_8)_:
-+1.1111111111111112 flow(storage_bus_el_2_8)
 -0.9 flow(bus_el_storage_2_8)
++1.1111111111111112 flow(storage_bus_el_2_8)
 -1 GenericInvestmentStorageBlock_storage_content(storage_7)
 +1 GenericInvestmentStorageBlock_storage_content(storage_8)
 = 0
@@ -458,39 +458,41 @@ bounds
    0 <= InvestmentFlowBlock_invest(bus_el_storage_0) <= 4
    0 <= InvestmentFlowBlock_invest(bus_el_storage_1) <= 4
    0 <= InvestmentFlowBlock_invest(bus_el_storage_2) <= 4
+   0 <= InvestmentFlowBlock_invest(storage_bus_el_0) <= +inf
+   0 <= InvestmentFlowBlock_invest(storage_bus_el_1) <= +inf
+   0 <= InvestmentFlowBlock_invest(storage_bus_el_2) <= +inf
    0 <= GenericInvestmentStorageBlock_invest(storage_0) <= 8
    0 <= GenericInvestmentStorageBlock_invest(storage_1) <= 8
    0 <= GenericInvestmentStorageBlock_invest(storage_2) <= 8
-   0 <= flow(storage_bus_el_0_0) <= +inf
    0 <= flow(bus_el_storage_0_0) <= +inf
-   0 <= flow(storage_bus_el_0_1) <= +inf
    0 <= flow(bus_el_storage_0_1) <= +inf
-   0 <= flow(storage_bus_el_0_2) <= +inf
    0 <= flow(bus_el_storage_0_2) <= +inf
-   0 <= flow(storage_bus_el_1_3) <= +inf
    0 <= flow(bus_el_storage_1_3) <= +inf
-   0 <= flow(storage_bus_el_1_4) <= +inf
    0 <= flow(bus_el_storage_1_4) <= +inf
-   0 <= flow(storage_bus_el_1_5) <= +inf
    0 <= flow(bus_el_storage_1_5) <= +inf
-   0 <= flow(storage_bus_el_2_6) <= +inf
    0 <= flow(bus_el_storage_2_6) <= +inf
-   0 <= flow(storage_bus_el_2_7) <= +inf
    0 <= flow(bus_el_storage_2_7) <= +inf
-   0 <= flow(storage_bus_el_2_8) <= +inf
    0 <= flow(bus_el_storage_2_8) <= +inf
+   0 <= flow(storage_bus_el_0_0) <= +inf
+   0 <= flow(storage_bus_el_0_1) <= +inf
+   0 <= flow(storage_bus_el_0_2) <= +inf
+   0 <= flow(storage_bus_el_1_3) <= +inf
+   0 <= flow(storage_bus_el_1_4) <= +inf
+   0 <= flow(storage_bus_el_1_5) <= +inf
+   0 <= flow(storage_bus_el_2_6) <= +inf
+   0 <= flow(storage_bus_el_2_7) <= +inf
+   0 <= flow(storage_bus_el_2_8) <= +inf
    0 <= InvestmentFlowBlock_total(bus_el_storage_0) <= +inf
    0 <= InvestmentFlowBlock_total(bus_el_storage_1) <= +inf
-   0 <= InvestmentFlowBlock_old(bus_el_storage_1) <= +inf
    0 <= InvestmentFlowBlock_total(bus_el_storage_2) <= +inf
-   0 <= InvestmentFlowBlock_old(bus_el_storage_2) <= +inf
    0 <= InvestmentFlowBlock_total(storage_bus_el_0) <= +inf
-   0 <= InvestmentFlowBlock_invest(storage_bus_el_0) <= +inf
    0 <= InvestmentFlowBlock_total(storage_bus_el_1) <= +inf
-   0 <= InvestmentFlowBlock_invest(storage_bus_el_1) <= +inf
-   0 <= InvestmentFlowBlock_old(storage_bus_el_1) <= +inf
    0 <= InvestmentFlowBlock_total(storage_bus_el_2) <= +inf
-   0 <= InvestmentFlowBlock_invest(storage_bus_el_2) <= +inf
+   0 <= InvestmentFlowBlock_old(bus_el_storage_0) <= +inf
+   0 <= InvestmentFlowBlock_old(bus_el_storage_1) <= +inf
+   0 <= InvestmentFlowBlock_old(bus_el_storage_2) <= +inf
+   0 <= InvestmentFlowBlock_old(storage_bus_el_0) <= +inf
+   0 <= InvestmentFlowBlock_old(storage_bus_el_1) <= +inf
    0 <= InvestmentFlowBlock_old(storage_bus_el_2) <= +inf
    0 <= InvestmentFlowBlock_old_end(bus_el_storage_0) <= +inf
    0 <= InvestmentFlowBlock_old_end(bus_el_storage_1) <= +inf
@@ -504,12 +506,11 @@ bounds
    0 <= InvestmentFlowBlock_old_exo(storage_bus_el_0) <= +inf
    0 <= InvestmentFlowBlock_old_exo(storage_bus_el_1) <= +inf
    0 <= InvestmentFlowBlock_old_exo(storage_bus_el_2) <= +inf
-   0 <= InvestmentFlowBlock_old(bus_el_storage_0) <= +inf
-   0 <= InvestmentFlowBlock_old(storage_bus_el_0) <= +inf
    0 <= GenericInvestmentStorageBlock_total(storage_0) <= +inf
    0 <= GenericInvestmentStorageBlock_total(storage_1) <= +inf
-   0 <= GenericInvestmentStorageBlock_old(storage_1) <= +inf
    0 <= GenericInvestmentStorageBlock_total(storage_2) <= +inf
+   0 <= GenericInvestmentStorageBlock_old(storage_0) <= +inf
+   0 <= GenericInvestmentStorageBlock_old(storage_1) <= +inf
    0 <= GenericInvestmentStorageBlock_old(storage_2) <= +inf
    0 <= GenericInvestmentStorageBlock_old_end(storage_0) <= +inf
    0 <= GenericInvestmentStorageBlock_old_end(storage_1) <= +inf
@@ -517,9 +518,8 @@ bounds
    0 <= GenericInvestmentStorageBlock_old_exo(storage_0) <= +inf
    0 <= GenericInvestmentStorageBlock_old_exo(storage_1) <= +inf
    0 <= GenericInvestmentStorageBlock_old_exo(storage_2) <= +inf
-   0 <= GenericInvestmentStorageBlock_old(storage_0) <= +inf
-   0 <= GenericInvestmentStorageBlock_storage_content(storage_1) <= +inf
    0 <= GenericInvestmentStorageBlock_storage_content(storage_0) <= +inf
+   0 <= GenericInvestmentStorageBlock_storage_content(storage_1) <= +inf
    0 <= GenericInvestmentStorageBlock_storage_content(storage_2) <= +inf
    0 <= GenericInvestmentStorageBlock_storage_content(storage_3) <= +inf
    0 <= GenericInvestmentStorageBlock_storage_content(storage_4) <= +inf

--- a/tests/_files/lp_files/multi-period/storage_investment_green_field_multi_period.lp
+++ b/tests/_files/lp_files/multi-period/storage_investment_green_field_multi_period.lp
@@ -1,59 +1,59 @@
 \* Source Pyomo model name=Model *\
 
-min
+min 
 objective:
-+793.9061073460653 InvestmentFlowBlock_invest(bus_el_storage_0)
-+577.5388911740415 InvestmentFlowBlock_invest(bus_el_storage_1)
-+424.1577145524276 InvestmentFlowBlock_invest(bus_el_storage_2)
-+2090.42853160222 GenericInvestmentStorageBlock_invest(storage_0)
-+1641.138857662593 GenericInvestmentStorageBlock_invest(storage_1)
-+1296.6801388085826 GenericInvestmentStorageBlock_invest(storage_2)
++740.3538603446715 InvestmentFlowBlock_invest(bus_el_storage_0)
++319.3808392388273 InvestmentFlowBlock_invest(bus_el_storage_1)
++23.270646132095994 InvestmentFlowBlock_invest(bus_el_storage_2)
++1800.3538603446716 GenericInvestmentStorageBlock_invest(storage_0)
++839.8454018911981 GenericInvestmentStorageBlock_invest(storage_1)
++66.04135320347618 GenericInvestmentStorageBlock_invest(storage_2)
 
 s.t.
 
 c_e_BusBlock_balance(bus_el_0_0)_:
-+1 flow(storage_bus_el_0_0)
 -1 flow(bus_el_storage_0_0)
++1 flow(storage_bus_el_0_0)
 = 0
 
 c_e_BusBlock_balance(bus_el_0_1)_:
-+1 flow(storage_bus_el_0_1)
 -1 flow(bus_el_storage_0_1)
++1 flow(storage_bus_el_0_1)
 = 0
 
 c_e_BusBlock_balance(bus_el_0_2)_:
-+1 flow(storage_bus_el_0_2)
 -1 flow(bus_el_storage_0_2)
++1 flow(storage_bus_el_0_2)
 = 0
 
 c_e_BusBlock_balance(bus_el_1_3)_:
-+1 flow(storage_bus_el_1_3)
 -1 flow(bus_el_storage_1_3)
++1 flow(storage_bus_el_1_3)
 = 0
 
 c_e_BusBlock_balance(bus_el_1_4)_:
-+1 flow(storage_bus_el_1_4)
 -1 flow(bus_el_storage_1_4)
++1 flow(storage_bus_el_1_4)
 = 0
 
 c_e_BusBlock_balance(bus_el_1_5)_:
-+1 flow(storage_bus_el_1_5)
 -1 flow(bus_el_storage_1_5)
++1 flow(storage_bus_el_1_5)
 = 0
 
 c_e_BusBlock_balance(bus_el_2_6)_:
-+1 flow(storage_bus_el_2_6)
 -1 flow(bus_el_storage_2_6)
++1 flow(storage_bus_el_2_6)
 = 0
 
 c_e_BusBlock_balance(bus_el_2_7)_:
-+1 flow(storage_bus_el_2_7)
 -1 flow(bus_el_storage_2_7)
++1 flow(storage_bus_el_2_7)
 = 0
 
 c_e_BusBlock_balance(bus_el_2_8)_:
-+1 flow(storage_bus_el_2_8)
 -1 flow(bus_el_storage_2_8)
++1 flow(storage_bus_el_2_8)
 = 0
 
 c_e_InvestmentFlowBlock_total_rule(bus_el_storage_0)_:
@@ -76,21 +76,21 @@ c_e_InvestmentFlowBlock_total_rule(bus_el_storage_2)_:
 = 0
 
 c_e_InvestmentFlowBlock_total_rule(storage_bus_el_0)_:
-+1 InvestmentFlowBlock_total(storage_bus_el_0)
 -1 InvestmentFlowBlock_invest(storage_bus_el_0)
++1 InvestmentFlowBlock_total(storage_bus_el_0)
 = 0
 
 c_e_InvestmentFlowBlock_total_rule(storage_bus_el_1)_:
+-1 InvestmentFlowBlock_invest(storage_bus_el_1)
 -1 InvestmentFlowBlock_total(storage_bus_el_0)
 +1 InvestmentFlowBlock_total(storage_bus_el_1)
--1 InvestmentFlowBlock_invest(storage_bus_el_1)
 +1 InvestmentFlowBlock_old(storage_bus_el_1)
 = 0
 
 c_e_InvestmentFlowBlock_total_rule(storage_bus_el_2)_:
+-1 InvestmentFlowBlock_invest(storage_bus_el_2)
 -1 InvestmentFlowBlock_total(storage_bus_el_1)
 +1 InvestmentFlowBlock_total(storage_bus_el_2)
--1 InvestmentFlowBlock_invest(storage_bus_el_2)
 +1 InvestmentFlowBlock_old(storage_bus_el_2)
 = 0
 
@@ -145,9 +145,9 @@ c_e_InvestmentFlowBlock_old_rule_exo(storage_bus_el_2)_:
 = 0
 
 c_e_InvestmentFlowBlock_old_rule(bus_el_storage_0)_:
++1 InvestmentFlowBlock_old(bus_el_storage_0)
 -1 InvestmentFlowBlock_old_end(bus_el_storage_0)
 -1 InvestmentFlowBlock_old_exo(bus_el_storage_0)
-+1 InvestmentFlowBlock_old(bus_el_storage_0)
 = 0
 
 c_e_InvestmentFlowBlock_old_rule(bus_el_storage_1)_:
@@ -163,9 +163,9 @@ c_e_InvestmentFlowBlock_old_rule(bus_el_storage_2)_:
 = 0
 
 c_e_InvestmentFlowBlock_old_rule(storage_bus_el_0)_:
++1 InvestmentFlowBlock_old(storage_bus_el_0)
 -1 InvestmentFlowBlock_old_end(storage_bus_el_0)
 -1 InvestmentFlowBlock_old_exo(storage_bus_el_0)
-+1 InvestmentFlowBlock_old(storage_bus_el_0)
 = 0
 
 c_e_InvestmentFlowBlock_old_rule(storage_bus_el_1)_:
@@ -315,9 +315,9 @@ c_e_GenericInvestmentStorageBlock_old_rule_exo(storage_2)_:
 = 0
 
 c_e_GenericInvestmentStorageBlock_old_rule(storage_0)_:
++1 GenericInvestmentStorageBlock_old(storage_0)
 -1 GenericInvestmentStorageBlock_old_end(storage_0)
 -1 GenericInvestmentStorageBlock_old_exo(storage_0)
-+1 GenericInvestmentStorageBlock_old(storage_0)
 = 0
 
 c_e_GenericInvestmentStorageBlock_old_rule(storage_1)_:
@@ -337,57 +337,57 @@ c_e_GenericInvestmentStorageBlock_initially_empty(storage_0)_:
 = 0
 
 c_e_GenericInvestmentStorageBlock_balance(storage_0_1)_:
-+1.1111111111111112 flow(storage_bus_el_0_1)
 -0.9 flow(bus_el_storage_0_1)
-+1 GenericInvestmentStorageBlock_storage_content(storage_1)
++1.1111111111111112 flow(storage_bus_el_0_1)
 -1 GenericInvestmentStorageBlock_storage_content(storage_0)
++1 GenericInvestmentStorageBlock_storage_content(storage_1)
 = 0
 
 c_e_GenericInvestmentStorageBlock_balance(storage_0_2)_:
-+1.1111111111111112 flow(storage_bus_el_0_2)
 -0.9 flow(bus_el_storage_0_2)
++1.1111111111111112 flow(storage_bus_el_0_2)
 -1 GenericInvestmentStorageBlock_storage_content(storage_1)
 +1 GenericInvestmentStorageBlock_storage_content(storage_2)
 = 0
 
 c_e_GenericInvestmentStorageBlock_balance(storage_1_3)_:
-+1.1111111111111112 flow(storage_bus_el_1_3)
 -0.9 flow(bus_el_storage_1_3)
++1.1111111111111112 flow(storage_bus_el_1_3)
 -1 GenericInvestmentStorageBlock_storage_content(storage_2)
 +1 GenericInvestmentStorageBlock_storage_content(storage_3)
 = 0
 
 c_e_GenericInvestmentStorageBlock_balance(storage_1_4)_:
-+1.1111111111111112 flow(storage_bus_el_1_4)
 -0.9 flow(bus_el_storage_1_4)
++1.1111111111111112 flow(storage_bus_el_1_4)
 -1 GenericInvestmentStorageBlock_storage_content(storage_3)
 +1 GenericInvestmentStorageBlock_storage_content(storage_4)
 = 0
 
 c_e_GenericInvestmentStorageBlock_balance(storage_1_5)_:
-+1.1111111111111112 flow(storage_bus_el_1_5)
 -0.9 flow(bus_el_storage_1_5)
++1.1111111111111112 flow(storage_bus_el_1_5)
 -1 GenericInvestmentStorageBlock_storage_content(storage_4)
 +1 GenericInvestmentStorageBlock_storage_content(storage_5)
 = 0
 
 c_e_GenericInvestmentStorageBlock_balance(storage_2_6)_:
-+1.1111111111111112 flow(storage_bus_el_2_6)
 -0.9 flow(bus_el_storage_2_6)
++1.1111111111111112 flow(storage_bus_el_2_6)
 -1 GenericInvestmentStorageBlock_storage_content(storage_5)
 +1 GenericInvestmentStorageBlock_storage_content(storage_6)
 = 0
 
 c_e_GenericInvestmentStorageBlock_balance(storage_2_7)_:
-+1.1111111111111112 flow(storage_bus_el_2_7)
 -0.9 flow(bus_el_storage_2_7)
++1.1111111111111112 flow(storage_bus_el_2_7)
 -1 GenericInvestmentStorageBlock_storage_content(storage_6)
 +1 GenericInvestmentStorageBlock_storage_content(storage_7)
 = 0
 
 c_e_GenericInvestmentStorageBlock_balance(storage_2_8)_:
-+1.1111111111111112 flow(storage_bus_el_2_8)
 -0.9 flow(bus_el_storage_2_8)
++1.1111111111111112 flow(storage_bus_el_2_8)
 -1 GenericInvestmentStorageBlock_storage_content(storage_7)
 +1 GenericInvestmentStorageBlock_storage_content(storage_8)
 = 0
@@ -456,39 +456,41 @@ bounds
    0 <= InvestmentFlowBlock_invest(bus_el_storage_0) <= 3
    0 <= InvestmentFlowBlock_invest(bus_el_storage_1) <= 3
    0 <= InvestmentFlowBlock_invest(bus_el_storage_2) <= 3
+   0 <= InvestmentFlowBlock_invest(storage_bus_el_0) <= +inf
+   0 <= InvestmentFlowBlock_invest(storage_bus_el_1) <= +inf
+   0 <= InvestmentFlowBlock_invest(storage_bus_el_2) <= +inf
    0 <= GenericInvestmentStorageBlock_invest(storage_0) <= 10
    0 <= GenericInvestmentStorageBlock_invest(storage_1) <= 10
    0 <= GenericInvestmentStorageBlock_invest(storage_2) <= 10
-   0 <= flow(storage_bus_el_0_0) <= +inf
    0 <= flow(bus_el_storage_0_0) <= +inf
-   0 <= flow(storage_bus_el_0_1) <= +inf
    0 <= flow(bus_el_storage_0_1) <= +inf
-   0 <= flow(storage_bus_el_0_2) <= +inf
    0 <= flow(bus_el_storage_0_2) <= +inf
-   0 <= flow(storage_bus_el_1_3) <= +inf
    0 <= flow(bus_el_storage_1_3) <= +inf
-   0 <= flow(storage_bus_el_1_4) <= +inf
    0 <= flow(bus_el_storage_1_4) <= +inf
-   0 <= flow(storage_bus_el_1_5) <= +inf
    0 <= flow(bus_el_storage_1_5) <= +inf
-   0 <= flow(storage_bus_el_2_6) <= +inf
    0 <= flow(bus_el_storage_2_6) <= +inf
-   0 <= flow(storage_bus_el_2_7) <= +inf
    0 <= flow(bus_el_storage_2_7) <= +inf
-   0 <= flow(storage_bus_el_2_8) <= +inf
    0 <= flow(bus_el_storage_2_8) <= +inf
+   0 <= flow(storage_bus_el_0_0) <= +inf
+   0 <= flow(storage_bus_el_0_1) <= +inf
+   0 <= flow(storage_bus_el_0_2) <= +inf
+   0 <= flow(storage_bus_el_1_3) <= +inf
+   0 <= flow(storage_bus_el_1_4) <= +inf
+   0 <= flow(storage_bus_el_1_5) <= +inf
+   0 <= flow(storage_bus_el_2_6) <= +inf
+   0 <= flow(storage_bus_el_2_7) <= +inf
+   0 <= flow(storage_bus_el_2_8) <= +inf
    0 <= InvestmentFlowBlock_total(bus_el_storage_0) <= +inf
    0 <= InvestmentFlowBlock_total(bus_el_storage_1) <= +inf
-   0 <= InvestmentFlowBlock_old(bus_el_storage_1) <= +inf
    0 <= InvestmentFlowBlock_total(bus_el_storage_2) <= +inf
-   0 <= InvestmentFlowBlock_old(bus_el_storage_2) <= +inf
    0 <= InvestmentFlowBlock_total(storage_bus_el_0) <= +inf
-   0 <= InvestmentFlowBlock_invest(storage_bus_el_0) <= +inf
    0 <= InvestmentFlowBlock_total(storage_bus_el_1) <= +inf
-   0 <= InvestmentFlowBlock_invest(storage_bus_el_1) <= +inf
-   0 <= InvestmentFlowBlock_old(storage_bus_el_1) <= +inf
    0 <= InvestmentFlowBlock_total(storage_bus_el_2) <= +inf
-   0 <= InvestmentFlowBlock_invest(storage_bus_el_2) <= +inf
+   0 <= InvestmentFlowBlock_old(bus_el_storage_0) <= +inf
+   0 <= InvestmentFlowBlock_old(bus_el_storage_1) <= +inf
+   0 <= InvestmentFlowBlock_old(bus_el_storage_2) <= +inf
+   0 <= InvestmentFlowBlock_old(storage_bus_el_0) <= +inf
+   0 <= InvestmentFlowBlock_old(storage_bus_el_1) <= +inf
    0 <= InvestmentFlowBlock_old(storage_bus_el_2) <= +inf
    0 <= InvestmentFlowBlock_old_end(bus_el_storage_0) <= +inf
    0 <= InvestmentFlowBlock_old_end(bus_el_storage_1) <= +inf
@@ -502,12 +504,11 @@ bounds
    0 <= InvestmentFlowBlock_old_exo(storage_bus_el_0) <= +inf
    0 <= InvestmentFlowBlock_old_exo(storage_bus_el_1) <= +inf
    0 <= InvestmentFlowBlock_old_exo(storage_bus_el_2) <= +inf
-   0 <= InvestmentFlowBlock_old(bus_el_storage_0) <= +inf
-   0 <= InvestmentFlowBlock_old(storage_bus_el_0) <= +inf
    0 <= GenericInvestmentStorageBlock_total(storage_0) <= +inf
    0 <= GenericInvestmentStorageBlock_total(storage_1) <= +inf
-   0 <= GenericInvestmentStorageBlock_old(storage_1) <= +inf
    0 <= GenericInvestmentStorageBlock_total(storage_2) <= +inf
+   0 <= GenericInvestmentStorageBlock_old(storage_0) <= +inf
+   0 <= GenericInvestmentStorageBlock_old(storage_1) <= +inf
    0 <= GenericInvestmentStorageBlock_old(storage_2) <= +inf
    0 <= GenericInvestmentStorageBlock_old_end(storage_0) <= +inf
    0 <= GenericInvestmentStorageBlock_old_end(storage_1) <= +inf
@@ -515,9 +516,8 @@ bounds
    0 <= GenericInvestmentStorageBlock_old_exo(storage_0) <= +inf
    0 <= GenericInvestmentStorageBlock_old_exo(storage_1) <= +inf
    0 <= GenericInvestmentStorageBlock_old_exo(storage_2) <= +inf
-   0 <= GenericInvestmentStorageBlock_old(storage_0) <= +inf
-   0 <= GenericInvestmentStorageBlock_storage_content(storage_1) <= +inf
    0 <= GenericInvestmentStorageBlock_storage_content(storage_0) <= +inf
+   0 <= GenericInvestmentStorageBlock_storage_content(storage_1) <= +inf
    0 <= GenericInvestmentStorageBlock_storage_content(storage_2) <= +inf
    0 <= GenericInvestmentStorageBlock_storage_content(storage_3) <= +inf
    0 <= GenericInvestmentStorageBlock_storage_content(storage_4) <= +inf

--- a/tests/_files/lp_files/multi-period/storage_multi_period.lp
+++ b/tests/_files/lp_files/multi-period/storage_multi_period.lp
@@ -1,10 +1,10 @@
 \* Source Pyomo model name=Model *\
 
-min
+min 
 objective:
 +500.35386034467155 InvestmentFlowBlock_invest(electricity_storage_0)
-+336.72380442191655 InvestmentFlowBlock_invest(electricity_storage_1)
-+226.6054675510339 InvestmentFlowBlock_invest(electricity_storage_2)
++201.53980618546032 InvestmentFlowBlock_invest(electricity_storage_1)
++13.586712455557082 InvestmentFlowBlock_invest(electricity_storage_2)
 +5 flow(storage_electricity_0_0)
 +5 flow(storage_electricity_0_1)
 +5 flow(storage_electricity_0_2)
@@ -14,73 +14,73 @@ objective:
 +3.3648566655402874 flow(storage_electricity_2_6)
 +3.3648566655402874 flow(storage_electricity_2_7)
 +3.3648566655402874 flow(storage_electricity_2_8)
-+512.5852039697296 GenericInvestmentStorageBlock_invest(storage_0)
-+346.75776636992174 GenericInvestmentStorageBlock_invest(storage_1)
-+234.83681117609197 GenericInvestmentStorageBlock_invest(storage_2)
++510.35386034467155 GenericInvestmentStorageBlock_invest(storage_0)
++206.4498492293506 GenericInvestmentStorageBlock_invest(storage_1)
++13.990209692079537 GenericInvestmentStorageBlock_invest(storage_2)
 
 s.t.
 
 c_e_BusBlock_balance(electricity_0_0)_:
-+1 flow(storage_electricity_0_0)
 -1 flow(electricity_storage_0_0)
++1 flow(storage_electricity_0_0)
 = 0
 
 c_e_BusBlock_balance(electricity_0_1)_:
-+1 flow(storage_electricity_0_1)
 -1 flow(electricity_storage_0_1)
++1 flow(storage_electricity_0_1)
 = 0
 
 c_e_BusBlock_balance(electricity_0_2)_:
-+1 flow(storage_electricity_0_2)
 -1 flow(electricity_storage_0_2)
++1 flow(storage_electricity_0_2)
 = 0
 
 c_e_BusBlock_balance(electricity_1_3)_:
-+1 flow(storage_electricity_1_3)
 -1 flow(electricity_storage_1_3)
++1 flow(storage_electricity_1_3)
 = 0
 
 c_e_BusBlock_balance(electricity_1_4)_:
-+1 flow(storage_electricity_1_4)
 -1 flow(electricity_storage_1_4)
++1 flow(storage_electricity_1_4)
 = 0
 
 c_e_BusBlock_balance(electricity_1_5)_:
-+1 flow(storage_electricity_1_5)
 -1 flow(electricity_storage_1_5)
++1 flow(storage_electricity_1_5)
 = 0
 
 c_e_BusBlock_balance(electricity_2_6)_:
-+1 flow(storage_electricity_2_6)
 -1 flow(electricity_storage_2_6)
++1 flow(storage_electricity_2_6)
 = 0
 
 c_e_BusBlock_balance(electricity_2_7)_:
-+1 flow(storage_electricity_2_7)
 -1 flow(electricity_storage_2_7)
++1 flow(storage_electricity_2_7)
 = 0
 
 c_e_BusBlock_balance(electricity_2_8)_:
-+1 flow(storage_electricity_2_8)
 -1 flow(electricity_storage_2_8)
++1 flow(storage_electricity_2_8)
 = 0
 
 c_e_InvestmentFlowBlock_total_rule(storage_electricity_0)_:
-+1 InvestmentFlowBlock_total(storage_electricity_0)
 -1 InvestmentFlowBlock_invest(storage_electricity_0)
++1 InvestmentFlowBlock_total(storage_electricity_0)
 = 0
 
 c_e_InvestmentFlowBlock_total_rule(storage_electricity_1)_:
+-1 InvestmentFlowBlock_invest(storage_electricity_1)
 -1 InvestmentFlowBlock_total(storage_electricity_0)
 +1 InvestmentFlowBlock_total(storage_electricity_1)
--1 InvestmentFlowBlock_invest(storage_electricity_1)
 +1 InvestmentFlowBlock_old(storage_electricity_1)
 = 0
 
 c_e_InvestmentFlowBlock_total_rule(storage_electricity_2)_:
+-1 InvestmentFlowBlock_invest(storage_electricity_2)
 -1 InvestmentFlowBlock_total(storage_electricity_1)
 +1 InvestmentFlowBlock_total(storage_electricity_2)
--1 InvestmentFlowBlock_invest(storage_electricity_2)
 +1 InvestmentFlowBlock_old(storage_electricity_2)
 = 0
 
@@ -154,9 +154,9 @@ c_e_InvestmentFlowBlock_old_rule_exo(electricity_storage_2)_:
 = 0
 
 c_e_InvestmentFlowBlock_old_rule(storage_electricity_0)_:
++1 InvestmentFlowBlock_old(storage_electricity_0)
 -1 InvestmentFlowBlock_old_end(storage_electricity_0)
 -1 InvestmentFlowBlock_old_exo(storage_electricity_0)
-+1 InvestmentFlowBlock_old(storage_electricity_0)
 = 0
 
 c_e_InvestmentFlowBlock_old_rule(storage_electricity_1)_:
@@ -172,9 +172,9 @@ c_e_InvestmentFlowBlock_old_rule(storage_electricity_2)_:
 = 0
 
 c_e_InvestmentFlowBlock_old_rule(electricity_storage_0)_:
++1 InvestmentFlowBlock_old(electricity_storage_0)
 -1 InvestmentFlowBlock_old_end(electricity_storage_0)
 -1 InvestmentFlowBlock_old_exo(electricity_storage_0)
-+1 InvestmentFlowBlock_old(electricity_storage_0)
 = 0
 
 c_e_InvestmentFlowBlock_old_rule(electricity_storage_1)_:
@@ -324,9 +324,9 @@ c_e_GenericInvestmentStorageBlock_old_rule_exo(storage_2)_:
 = 0
 
 c_e_GenericInvestmentStorageBlock_old_rule(storage_0)_:
++1 GenericInvestmentStorageBlock_old(storage_0)
 -1 GenericInvestmentStorageBlock_old_end(storage_0)
 -1 GenericInvestmentStorageBlock_old_exo(storage_0)
-+1 GenericInvestmentStorageBlock_old(storage_0)
 = 0
 
 c_e_GenericInvestmentStorageBlock_old_rule(storage_1)_:
@@ -346,57 +346,57 @@ c_e_GenericInvestmentStorageBlock_initially_empty(storage_0)_:
 = 0
 
 c_e_GenericInvestmentStorageBlock_balance(storage_0_1)_:
-+1 flow(storage_electricity_0_1)
 -1 flow(electricity_storage_0_1)
-+1 GenericInvestmentStorageBlock_storage_content(storage_1)
++1 flow(storage_electricity_0_1)
 -1 GenericInvestmentStorageBlock_storage_content(storage_0)
++1 GenericInvestmentStorageBlock_storage_content(storage_1)
 = 0
 
 c_e_GenericInvestmentStorageBlock_balance(storage_0_2)_:
-+1 flow(storage_electricity_0_2)
 -1 flow(electricity_storage_0_2)
++1 flow(storage_electricity_0_2)
 -1 GenericInvestmentStorageBlock_storage_content(storage_1)
 +1 GenericInvestmentStorageBlock_storage_content(storage_2)
 = 0
 
 c_e_GenericInvestmentStorageBlock_balance(storage_1_3)_:
-+1 flow(storage_electricity_1_3)
 -1 flow(electricity_storage_1_3)
++1 flow(storage_electricity_1_3)
 -1 GenericInvestmentStorageBlock_storage_content(storage_2)
 +1 GenericInvestmentStorageBlock_storage_content(storage_3)
 = 0
 
 c_e_GenericInvestmentStorageBlock_balance(storage_1_4)_:
-+1 flow(storage_electricity_1_4)
 -1 flow(electricity_storage_1_4)
++1 flow(storage_electricity_1_4)
 -1 GenericInvestmentStorageBlock_storage_content(storage_3)
 +1 GenericInvestmentStorageBlock_storage_content(storage_4)
 = 0
 
 c_e_GenericInvestmentStorageBlock_balance(storage_1_5)_:
-+1 flow(storage_electricity_1_5)
 -1 flow(electricity_storage_1_5)
++1 flow(storage_electricity_1_5)
 -1 GenericInvestmentStorageBlock_storage_content(storage_4)
 +1 GenericInvestmentStorageBlock_storage_content(storage_5)
 = 0
 
 c_e_GenericInvestmentStorageBlock_balance(storage_2_6)_:
-+1 flow(storage_electricity_2_6)
 -1 flow(electricity_storage_2_6)
++1 flow(storage_electricity_2_6)
 -1 GenericInvestmentStorageBlock_storage_content(storage_5)
 +1 GenericInvestmentStorageBlock_storage_content(storage_6)
 = 0
 
 c_e_GenericInvestmentStorageBlock_balance(storage_2_7)_:
-+1 flow(storage_electricity_2_7)
 -1 flow(electricity_storage_2_7)
++1 flow(storage_electricity_2_7)
 -1 GenericInvestmentStorageBlock_storage_content(storage_6)
 +1 GenericInvestmentStorageBlock_storage_content(storage_7)
 = 0
 
 c_e_GenericInvestmentStorageBlock_balance(storage_2_8)_:
-+1 flow(storage_electricity_2_8)
 -1 flow(electricity_storage_2_8)
++1 flow(storage_electricity_2_8)
 -1 GenericInvestmentStorageBlock_storage_content(storage_7)
 +1 GenericInvestmentStorageBlock_storage_content(storage_8)
 = 0
@@ -477,9 +477,21 @@ c_u_GenericInvestmentStorageBlock_max_storage_content(storage_2_8)_:
 <= 0
 
 bounds
+   0 <= InvestmentFlowBlock_invest(storage_electricity_0) <= +inf
+   0 <= InvestmentFlowBlock_invest(storage_electricity_1) <= +inf
+   0 <= InvestmentFlowBlock_invest(storage_electricity_2) <= +inf
    0 <= InvestmentFlowBlock_invest(electricity_storage_0) <= +inf
    0 <= InvestmentFlowBlock_invest(electricity_storage_1) <= +inf
    0 <= InvestmentFlowBlock_invest(electricity_storage_2) <= +inf
+   0 <= flow(electricity_storage_0_0) <= +inf
+   0 <= flow(electricity_storage_0_1) <= +inf
+   0 <= flow(electricity_storage_0_2) <= +inf
+   0 <= flow(electricity_storage_1_3) <= +inf
+   0 <= flow(electricity_storage_1_4) <= +inf
+   0 <= flow(electricity_storage_1_5) <= +inf
+   0 <= flow(electricity_storage_2_6) <= +inf
+   0 <= flow(electricity_storage_2_7) <= +inf
+   0 <= flow(electricity_storage_2_8) <= +inf
    0 <= flow(storage_electricity_0_0) <= +inf
    0 <= flow(storage_electricity_0_1) <= +inf
    0 <= flow(storage_electricity_0_2) <= +inf
@@ -492,27 +504,17 @@ bounds
    0 <= GenericInvestmentStorageBlock_invest(storage_0) <= +inf
    0 <= GenericInvestmentStorageBlock_invest(storage_1) <= +inf
    0 <= GenericInvestmentStorageBlock_invest(storage_2) <= +inf
-   0 <= flow(electricity_storage_0_0) <= +inf
-   0 <= flow(electricity_storage_0_1) <= +inf
-   0 <= flow(electricity_storage_0_2) <= +inf
-   0 <= flow(electricity_storage_1_3) <= +inf
-   0 <= flow(electricity_storage_1_4) <= +inf
-   0 <= flow(electricity_storage_1_5) <= +inf
-   0 <= flow(electricity_storage_2_6) <= +inf
-   0 <= flow(electricity_storage_2_7) <= +inf
-   0 <= flow(electricity_storage_2_8) <= +inf
    0 <= InvestmentFlowBlock_total(storage_electricity_0) <= +inf
-   0 <= InvestmentFlowBlock_invest(storage_electricity_0) <= +inf
    0 <= InvestmentFlowBlock_total(storage_electricity_1) <= +inf
-   0 <= InvestmentFlowBlock_invest(storage_electricity_1) <= +inf
-   0 <= InvestmentFlowBlock_old(storage_electricity_1) <= +inf
    0 <= InvestmentFlowBlock_total(storage_electricity_2) <= +inf
-   0 <= InvestmentFlowBlock_invest(storage_electricity_2) <= +inf
-   0 <= InvestmentFlowBlock_old(storage_electricity_2) <= +inf
    0 <= InvestmentFlowBlock_total(electricity_storage_0) <= +inf
    0 <= InvestmentFlowBlock_total(electricity_storage_1) <= +inf
-   0 <= InvestmentFlowBlock_old(electricity_storage_1) <= +inf
    0 <= InvestmentFlowBlock_total(electricity_storage_2) <= +inf
+   0 <= InvestmentFlowBlock_old(storage_electricity_0) <= +inf
+   0 <= InvestmentFlowBlock_old(storage_electricity_1) <= +inf
+   0 <= InvestmentFlowBlock_old(storage_electricity_2) <= +inf
+   0 <= InvestmentFlowBlock_old(electricity_storage_0) <= +inf
+   0 <= InvestmentFlowBlock_old(electricity_storage_1) <= +inf
    0 <= InvestmentFlowBlock_old(electricity_storage_2) <= +inf
    0 <= InvestmentFlowBlock_old_end(storage_electricity_0) <= +inf
    0 <= InvestmentFlowBlock_old_end(storage_electricity_1) <= +inf
@@ -526,12 +528,11 @@ bounds
    0 <= InvestmentFlowBlock_old_exo(electricity_storage_0) <= +inf
    0 <= InvestmentFlowBlock_old_exo(electricity_storage_1) <= +inf
    0 <= InvestmentFlowBlock_old_exo(electricity_storage_2) <= +inf
-   0 <= InvestmentFlowBlock_old(storage_electricity_0) <= +inf
-   0 <= InvestmentFlowBlock_old(electricity_storage_0) <= +inf
    0 <= GenericInvestmentStorageBlock_total(storage_0) <= +inf
    0 <= GenericInvestmentStorageBlock_total(storage_1) <= +inf
-   0 <= GenericInvestmentStorageBlock_old(storage_1) <= +inf
    0 <= GenericInvestmentStorageBlock_total(storage_2) <= +inf
+   0 <= GenericInvestmentStorageBlock_old(storage_0) <= +inf
+   0 <= GenericInvestmentStorageBlock_old(storage_1) <= +inf
    0 <= GenericInvestmentStorageBlock_old(storage_2) <= +inf
    0 <= GenericInvestmentStorageBlock_old_end(storage_0) <= +inf
    0 <= GenericInvestmentStorageBlock_old_end(storage_1) <= +inf
@@ -539,9 +540,8 @@ bounds
    0 <= GenericInvestmentStorageBlock_old_exo(storage_0) <= +inf
    0 <= GenericInvestmentStorageBlock_old_exo(storage_1) <= +inf
    0 <= GenericInvestmentStorageBlock_old_exo(storage_2) <= +inf
-   0 <= GenericInvestmentStorageBlock_old(storage_0) <= +inf
-   0 <= GenericInvestmentStorageBlock_storage_content(storage_1) <= +inf
    0 <= GenericInvestmentStorageBlock_storage_content(storage_0) <= +inf
+   0 <= GenericInvestmentStorageBlock_storage_content(storage_1) <= +inf
    0 <= GenericInvestmentStorageBlock_storage_content(storage_2) <= +inf
    0 <= GenericInvestmentStorageBlock_storage_content(storage_3) <= +inf
    0 <= GenericInvestmentStorageBlock_storage_content(storage_4) <= +inf

--- a/tests/_files/lp_files/multi-period/volatile_multi_period.lp
+++ b/tests/_files/lp_files/multi-period/volatile_multi_period.lp
@@ -3,9 +3,9 @@
 min 
 objective:
 +3931.8746311756586 ONE_VAR_CONSTANT
-+683.8240147205426 InvestmentFlowBlock_invest(wind_bus_el_0)
-+487.2332336419946 InvestmentFlowBlock_invest(wind_bus_el_1)
-+350.07562192690494 InvestmentFlowBlock_invest(wind_bus_el_2)
++650.3538603446716 InvestmentFlowBlock_invest(wind_bus_el_0)
++275.1904518438147 InvestmentFlowBlock_invest(wind_bus_el_1)
++19.6391710033939 InvestmentFlowBlock_invest(wind_bus_el_2)
 
 s.t.
 
@@ -90,9 +90,9 @@ c_e_InvestmentFlowBlock_old_rule_exo(wind_bus_el_2)_:
 = 10
 
 c_e_InvestmentFlowBlock_old_rule(wind_bus_el_0)_:
++1 InvestmentFlowBlock_old(wind_bus_el_0)
 -1 InvestmentFlowBlock_old_end(wind_bus_el_0)
 -1 InvestmentFlowBlock_old_exo(wind_bus_el_0)
-+1 InvestmentFlowBlock_old(wind_bus_el_0)
 = 0
 
 c_e_InvestmentFlowBlock_old_rule(wind_bus_el_1)_:
@@ -168,8 +168,9 @@ bounds
    0 <= flow(wind_bus_el_2_8) <= +inf
    0 <= InvestmentFlowBlock_total(wind_bus_el_0) <= +inf
    0 <= InvestmentFlowBlock_total(wind_bus_el_1) <= +inf
-   0 <= InvestmentFlowBlock_old(wind_bus_el_1) <= +inf
    0 <= InvestmentFlowBlock_total(wind_bus_el_2) <= +inf
+   0 <= InvestmentFlowBlock_old(wind_bus_el_0) <= +inf
+   0 <= InvestmentFlowBlock_old(wind_bus_el_1) <= +inf
    0 <= InvestmentFlowBlock_old(wind_bus_el_2) <= +inf
    0 <= InvestmentFlowBlock_old_end(wind_bus_el_0) <= +inf
    0 <= InvestmentFlowBlock_old_end(wind_bus_el_1) <= +inf
@@ -177,5 +178,4 @@ bounds
    0 <= InvestmentFlowBlock_old_exo(wind_bus_el_0) <= +inf
    0 <= InvestmentFlowBlock_old_exo(wind_bus_el_1) <= +inf
    0 <= InvestmentFlowBlock_old_exo(wind_bus_el_2) <= +inf
-   0 <= InvestmentFlowBlock_old(wind_bus_el_0) <= +inf
 end


### PR DESCRIPTION
# Description
Upgrade to oemof.solph 0.5.2dev1. Therefore Adjustments in LP files are necessary since end of life cost calculation changed. 

Breaks LP file test if run with older solph version.

Fixes #155 

## Type of change

Please tick or delete options that are not relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

Please tick or delete options that are not relevant.

- [x] New and adjusted code is formatted using the `pre-commit` hooks
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] If new packages are needed, I added them the [setup.py](https://github.com/oemof/oemof-tabular/blob/dev/setup.py#L67-L80)
- [x] I have added my name to [AUTHORS]((https://github.com/oemof/oemof-tabular/tree/dev/AUTHORS.rst)
)
