### PR TITLE
Fix oemof.solph version from 0.5.2dev1 to existing tag 0.5.2.dev1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,7 @@ Fixes
 
 * Remove specific dirs from flake8 & isort `#136 <https://github.com/oemof/oemof-tabular/pull/136>`_
 * Update lp-files to pyomo6.7 `#148 <https://github.com/oemof/oemof-tabular/pull/148>`_
+* Fix oemof.solph version on dev `#159 <https://github.com/oemof/oemof-tabular/pull/159>`_
 
 
 

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ setup(
         # "oemof.solph>=0.5.1",
         # Upcomming upgrade to solph 0.5.2 postponed due to many changes necessary for implementing
         # explicit arguments and upgrade to network 0.5.1
-        "oemof.solph==0.5.2dev1",
+        "oemof.solph==0.5.2.dev1",
         "pandas>=0.22",
         "oemof.network==0.5.0a4",  # Temporal fix due to braking changes in 0.5.1
         "paramiko",


### PR DESCRIPTION
# Description

With this PR it is possible to install oemof.solph==0.5.2.dev1 via poetry.

Fixes #158

## Type of change

Please tick or delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- ~[ ] New feature (non-breaking change which adds functionality)~
- ~[ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)~

# Checklist:

Please tick or delete options that are not relevant.

- ~[ ] New and adjusted code is formatted using the `pre-commit` hooks~
- ~[ ] I have commented my code, particularly in hard-to-understand areas~
- ~[ ] I have made corresponding changes to the documentation~
- ~[ ] I have added tests that prove my fix is effective or that my feature works~
- ~[ ] New and existing unit tests pass locally with my changes~
- ~[ ] If new packages are needed, I added them the [setup.py](https://github.com/oemof/oemof-tabular/blob/dev/setup.py#L67-L80)~
- [x] I have added new features/fixes to the [CHANGELOG](https://github.com/oemof/oemof-tabular/tree/dev/CHANGELOG.rst)
- ~[ ] I have added my name to [AUTHORS]((https://github.com/oemof/oemof-tabular/tree/dev/AUTHORS.rst)
)~
