### PR TITLE
Add flag use_representative_years to ES for multi-year-period cost accounting

### DIFF
--- a/src/oemof/tabular/datapackage/reading.py
+++ b/src/oemof/tabular/datapackage/reading.py
@@ -605,11 +605,13 @@ def deserialize_energy_system(cls, path, typemap={}, attributemap={}):
         else:
             # look for periods resource and if present, take periods from it
             if package.get_resource("periods"):
+                use_representative_years = True if period_data["years"].size>1 else False
                 es = cls(
                     timeindex=period_data["timeindex"],
                     timeincrement=period_data["timeincrement"],
                     periods=period_data["periods"],
                     infer_last_interval=False,
+                    use_representative_years=use_representative_years,
                 )
 
             # if lst is not empty


### PR DESCRIPTION
# Description

Fixes #163

Implements `use_representative_years` to use accounting for multi-year-periods in solph, see https://github.com/oemof/oemof-solph/pull/993

**Attention**: Might not be possible to merge this to dev, as solph branch will not be merged into dev, and therefore might be a feature which can lead to erros due to passing the parameter `use_representative_years` to `energy_system` if not existent.

## Type of change

Please tick or delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

Please tick or delete options that are not relevant.

- [ ] New and adjusted code is formatted using the `pre-commit` hooks
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] If new packages are needed, I added them the [setup.py](https://github.com/oemof/oemof-tabular/blob/dev/setup.py#L67-L80)
- [ ] I have added new features/fixes to the [CHANGELOG](https://github.com/oemof/oemof-tabular/tree/dev/CHANGELOG.rst)
- [ ] I have added my name to [AUTHORS]((https://github.com/oemof/oemof-tabular/tree/dev/AUTHORS.rst)
)
