### PR TITLE
Infer metadata from the data *.csv file

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -14,3 +14,4 @@ Authors
 * Marie-Claire Gering
 * Julian Endres
 * Felix Maurer
+* Pierre-Francois Duc

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,7 @@ Unreleased
 ----------
 
 Features
+* Improve the function to infer package metadata `#173 <https://github.com/oemof/oemof-tabular/pull/173>`_
 
 Fixes
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -172,6 +172,18 @@ To create meta-data `json` file you can use the following code:
 
 	from datapackage_utilities import building
 
+	building.infer_metadata_from_data(
+		package_name="my-datapackage",
+		path="/home/user/datpackages/my-datapackage"
+	)
+
+
+Or, if you want to specify manually the relation of the foreign keys, you can use this code:
+
+.. code-block:: python
+
+	from datapackage_utilities import building
+
 	building.infer_metadata(
 		package_name="my-datapackage",
 		foreign_keys={
@@ -354,7 +366,8 @@ field names in the generators-profile resource.
 	.. note::
 
 		This usage breaks with the datapackage standard and creates
-		non-valid resources.**
+		non-valid resources.
+
 
 
 Scripting

--- a/src/oemof/tabular/__init__.py
+++ b/src/oemof/tabular/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.0.5"
+__version__ = "0.0.6dev"
 __project__ = "oemof.tabular"
 
 

--- a/src/oemof/tabular/config/config.py
+++ b/src/oemof/tabular/config/config.py
@@ -18,6 +18,11 @@ FOREIGN_KEY_DESCRIPTORS_FILE = os.environ.get(
 with open(FOREIGN_KEY_DESCRIPTORS_FILE, "r") as fk_descriptors_file:
     FOREIGN_KEY_DESCRIPTORS = json.load(fk_descriptors_file)
 
+SPECIAL_FIELD_NAMES = {}
+for fk, descriptor in FOREIGN_KEY_DESCRIPTORS.items():
+    for el in descriptor:
+        SPECIAL_FIELD_NAMES[el["fields"]] = fk
+
 supported_oemof_tabular_versions = [
     None,
     "0.0.1",

--- a/src/oemof/tabular/datapackage/building.py
+++ b/src/oemof/tabular/datapackage/building.py
@@ -107,7 +107,7 @@ def map_sequence_profiles_to_resource_name(
 
     if duplicated_labels:
         # write an error message here
-        pass
+        raise ValueError(f"The following sequences labels are not unique across all sequences files: {', '.join(duplicated_labels)} ")
     # map each profile to its resource name
     sequences_mapping = {
         value: key for (key, values) in sequences.items() for value in values

--- a/src/oemof/tabular/datapackage/building.py
+++ b/src/oemof/tabular/datapackage/building.py
@@ -107,7 +107,9 @@ def map_sequence_profiles_to_resource_name(
 
     if duplicated_labels:
         # write an error message here
-        raise ValueError(f"The following sequences labels are not unique across all sequences files: {', '.join(duplicated_labels)} ")
+        raise ValueError(
+            f"The following sequences labels are not unique across all sequences files: {', '.join(duplicated_labels)} "
+        )
     # map each profile to its resource name
     sequences_mapping = {
         value: key for (key, values) in sequences.items() for value in values

--- a/src/oemof/tabular/datapackage/building.py
+++ b/src/oemof/tabular/datapackage/building.py
@@ -63,9 +63,10 @@ def update_package_descriptor():
 def map_sequence_profiles_to_resource_name(
     p, excluded_profiles=("timeindex",)
 ):
-    """Look in every resource which is a sequence and map each of its fields to itself
+    """Look in every sequence resources and map each of its fields to itself
 
-    Within this process the unicity of the field names will be checked, with the exception of the field "timeindex"
+    Within this process the unicity of the field names will be checked,
+    with the exception of the field "timeindex"
 
     """
 
@@ -82,7 +83,9 @@ def map_sequence_profiles_to_resource_name(
 
         if answer:
             warnings.warn(
-                f"The labels of the profiles are not unique across all files within 'sequences' folder: '{','.join(intersect)}' used more than once"
+                f"The labels of the profiles are not unique across all"
+                f"files within 'sequences' folder: '{','.join(intersect)}' "
+                f"used more than once"
             )
         return answer
 
@@ -115,13 +118,16 @@ def map_sequence_profiles_to_resource_name(
 def infer_resource_foreign_keys(resource, sequences_profiles_to_resource):
     """Find out the foreign keys within a resource fields
 
-    Look through all field of a resource which are of type 'string' if any of their values are matching a profile header in any of the sequences resources
+    Look through all field of a resource which are of type 'string'
+    if any of their values are matching a profile header in any of
+    the sequences resources
 
 
     Parameters
     ----------
     resource: a :datapackage.Resource: instance
-    sequences_profiles_to_resource: the mapping of sequence profile headers to their resource name
+    sequences_profiles_to_resource: the mapping of sequence profile
+        headers to their resource name
 
     Returns
     -------
@@ -140,7 +146,8 @@ def infer_resource_foreign_keys(resource, sequences_profiles_to_resource):
             for potential_fk in data.dropna()[field.name].unique():
 
                 if potential_fk in sequences_profiles_to_resource:
-                    # this is actually a wrong format and should be with a "fields" field under the "reference" fields
+                    # this is actually a wrong format and should be
+                    # with a "fields" field under the "reference" fields
 
                     fk = {
                         "fields": field.name,
@@ -158,7 +165,7 @@ def infer_resource_foreign_keys(resource, sequences_profiles_to_resource):
 
 
 def infer_package_foreign_keys(package):
-    """Infer the foreign_keys from data/elements and data/sequences and update meta data
+    """Infer the foreign_keys from elements and sequences and update meta data
 
     Parameters
     ----------
@@ -200,9 +207,11 @@ def infer_metadata_from_data(
     foreign_keys = {}
 
     def infer_resource_basic_foreign_keys(resource):
-        """insert resource foreign_key into a dict formatted for building.infer_metadata
+        """Prepare foreign_keys dict for building.infer_metadata
 
-        Compare the fields of a resource to a list of field names known to be foreign keys. If the field name is within the list, it is used to populate the dict 'foreign_keys'
+        Compare the fields of a resource to a list of field names known
+        to be foreign keys. If the field name is within the list, it is
+        used to populate the dict 'foreign_keys'
         """
         for field in resource.schema.fields:
             if field.name in config.SPECIAL_FIELD_NAMES:

--- a/src/oemof/tabular/datapackage/building.py
+++ b/src/oemof/tabular/datapackage/building.py
@@ -147,7 +147,7 @@ def infer_resource_foreign_keys(resource, sequences_profiles_to_resource):
 
     for field in r.schema.fields:
         if field.type == "string":
-            for potential_fk in data.dropna()[field.name].unique():
+            for potential_fk in data[field.name].dropna().unique():
 
                 if potential_fk in sequences_profiles_to_resource:
                     # this is actually a wrong format and should be

--- a/src/oemof/tabular/datapackage/building.py
+++ b/src/oemof/tabular/datapackage/building.py
@@ -179,7 +179,7 @@ def infer_package_foreign_keys(package):
     sequences_profiles_to_resource = map_sequence_profiles_to_resource_name(p)
 
     for r in p.resources:
-        if "/elements/" in r.descriptor["path"]:
+        if os.sep + "elements" + os.sep in r.descriptor["path"]:
             r = infer_resource_foreign_keys(r, sequences_profiles_to_resource)
             p.remove_resource(r.name)
             p.add_resource(r.descriptor)
@@ -213,7 +213,7 @@ def infer_metadata_from_data(
     # Infer the fields from the package data
     path = os.path.abspath(path)
     p0 = Package(base_path=path)
-    p0.infer(os.path.join(path, "**/*.csv"))
+    p0.infer(os.path.join(path, "**" + os.sep + "*.csv"))
     p0.commit()
     p0.save(os.path.join(path, metadata_filename))
 
@@ -236,7 +236,7 @@ def infer_metadata_from_data(
                     foreign_keys[fk_descriptor] = [resource.name]
 
     for r in p0.resources:
-        if "/elements/" in r.descriptor["path"]:
+        if os.sep + "elements" + os.sep in r.descriptor["path"]:
             infer_resource_basic_foreign_keys(r)
     # this function saves the metadata of the package in json format
     infer_metadata(

--- a/src/oemof/tabular/datapackage/building.py
+++ b/src/oemof/tabular/datapackage/building.py
@@ -185,6 +185,10 @@ def infer_package_foreign_keys(package):
     for r in p.resources:
         if os.sep + "elements" + os.sep in r.descriptor["path"]:
             r = infer_resource_foreign_keys(r, sequences_profiles_to_resource)
+            # sort foreign_key entries by alphabetically by fields
+            r.descriptor["schema"]["foreignKeys"].sort(
+                key=lambda x: x["fields"]
+            )
             p.remove_resource(r.name)
             p.add_resource(r.descriptor)
 
@@ -430,6 +434,7 @@ def infer_metadata(
             )
             p.add_resource(r.descriptor)
 
+    p.descriptor["resources"].sort(key=lambda x: (x["path"], x["name"]))
     p.commit()
     p.save(metadata_filename)
 

--- a/src/oemof/tabular/datapackage/building.py
+++ b/src/oemof/tabular/datapackage/building.py
@@ -186,15 +186,28 @@ def infer_package_foreign_keys(package):
 
 
 def infer_metadata_from_data(
+    path,
     package_name="default-name",
-    path=None,
     metadata_filename="datapackage.json",
 ):
-    """
+    """Creates a metadata .json file at the root-folder of datapackage
+
+    The foreign keys are inferred from the csv files within
+    "data/elements" and "data/sequences" resources.
+
+    Parameters
+    ----------
+    path: string
+        Absolute path to root-folder of the datapackage
+    package_name: string
+        Name of the data package
+    metadata_filename: basestring
+        Name of the inferred metadata string.
 
     Returns
     -------
-
+    Save a json metadata file at the root-folder of datapackage
+    under the provided path.
     """
 
     # Infer the fields from the package data

--- a/src/oemof/tabular/datapackage/building.py
+++ b/src/oemof/tabular/datapackage/building.py
@@ -6,6 +6,7 @@ import shutil
 import sys
 import tarfile
 import urllib.request
+import warnings
 import zipfile
 from ftplib import FTP
 from urllib.parse import urlparse
@@ -57,6 +58,178 @@ def update_package_descriptor():
     os.rmdir("resources")
 
     p.save("datapackage.json")
+
+
+def map_sequence_profiles_to_resource_name(
+    p, excluded_profiles=("timeindex",)
+):
+    """Look in every resource which is a sequence and map each of its fields to itself
+
+    Within this process the unicity of the field names will be checked, with the exception of the field "timeindex"
+
+    """
+
+    def check_sequences_labels_unicity(labels, new_labels):
+        intersect = set(labels).intersection(new_labels)
+        if len(intersect) == 1:
+            intersect = intersect.pop()
+            if not intersect == "timeindex":
+                answer = [intersect]
+            else:
+                answer = []
+        else:
+            answer = list(intersect)
+
+        if answer:
+            warnings.warn(
+                f"The labels of the profiles are not unique across all files within 'sequences' folder: '{','.join(intersect)}' used more than once"
+            )
+        return answer
+
+    sequences = {}
+    sequence_labels = []
+    duplicated_labels = []
+    for r in p.resources:
+        if "/sequences/" in r.descriptor["path"]:
+            field_labels = [
+                f.name
+                for f in r.schema.fields
+                if f.name not in excluded_profiles
+            ]
+            sequences[r.descriptor["name"]] = field_labels
+            duplicated_labels += check_sequences_labels_unicity(
+                sequence_labels, field_labels
+            )
+            sequence_labels += field_labels
+
+    if duplicated_labels:
+        # write an error message here
+        pass
+    # map each profile to its resource name
+    sequences_mapping = {
+        value: key for (key, values) in sequences.items() for value in values
+    }
+    return sequences_mapping
+
+
+def infer_resource_foreign_keys(resource, sequences_profiles_to_resource):
+    """Find out the foreign keys within a resource fields
+
+    Look through all field of a resource which are of type 'string' if any of their values are matching a profile header in any of the sequences resources
+
+
+    Parameters
+    ----------
+    resource: a :datapackage.Resource: instance
+    sequences_profiles_to_resource: the mapping of sequence profile headers to their resource name
+
+    Returns
+    -------
+    The :datapackage.Resource: instance with updated "foreignKeys" field
+
+    """
+    r = resource
+    data = pd.DataFrame.from_records(r.read(keyed=True))
+    # TODO not sure this should be set here
+    r.descriptor["schema"]["primaryKey"] = "name"
+    if "foreignKeys" not in r.descriptor["schema"]:
+        r.descriptor["schema"]["foreignKeys"] = []
+
+    for field in r.schema.fields:
+        if field.type == "string":
+            for potential_fk in data.dropna()[field.name].unique():
+
+                if potential_fk in sequences_profiles_to_resource:
+                    # this is actually a wrong format and should be with a "fields" field under the "reference" fields
+
+                    fk = {
+                        "fields": field.name,
+                        "reference": {
+                            "resource": sequences_profiles_to_resource[
+                                potential_fk
+                            ],
+                        },
+                    }
+
+                    if fk not in r.descriptor["schema"]["foreignKeys"]:
+                        r.descriptor["schema"]["foreignKeys"].append(fk)
+    r.commit()
+    return r
+
+
+def infer_package_foreign_keys(package):
+    """Infer the foreign_keys from data/elements and data/sequences and update meta data
+
+    Parameters
+    ----------
+    package
+
+    Returns
+    -------
+
+    """
+    p = package
+    sequences_profiles_to_resource = map_sequence_profiles_to_resource_name(p)
+
+    for r in p.resources:
+        if "/elements/" in r.descriptor["path"]:
+            r = infer_resource_foreign_keys(r, sequences_profiles_to_resource)
+            p.remove_resource(r.name)
+            p.add_resource(r.descriptor)
+
+
+def infer_metadata_from_data(
+    package_name="default-name",
+    path=None,
+    metadata_filename="datapackage.json",
+):
+    """
+
+    Returns
+    -------
+
+    """
+
+    # Infer the fields from the package data
+    path = os.path.abspath(path)
+    p0 = Package(base_path=path)
+    p0.infer(os.path.join(path, "**/*.csv"))
+    p0.commit()
+    p0.save(os.path.join(path, metadata_filename))
+
+    foreign_keys = {}
+
+    def infer_resource_basic_foreign_keys(resource):
+        """insert resource foreign_key into a dict formatted for building.infer_metadata
+
+        Compare the fields of a resource to a list of field names known to be foreign keys. If the field name is within the list, it is used to populate the dict 'foreign_keys'
+        """
+        for field in resource.schema.fields:
+            if field.name in config.SPECIAL_FIELD_NAMES:
+                fk_descriptor = config.SPECIAL_FIELD_NAMES[field.name]
+                if fk_descriptor in foreign_keys:
+                    if resource.name not in foreign_keys[fk_descriptor]:
+                        foreign_keys[fk_descriptor].append(resource.name)
+                else:
+                    foreign_keys[fk_descriptor] = [resource.name]
+
+    for r in p0.resources:
+        if "/elements/" in r.descriptor["path"]:
+            infer_resource_basic_foreign_keys(r)
+    # this function saves the metadata of the package in json format
+    infer_metadata(
+        package_name=package_name,
+        path=path,
+        foreign_keys=foreign_keys,
+        metadata_filename=metadata_filename,
+    )
+
+    # reload the package from the saved json file
+    p = Package(os.path.join(path, metadata_filename))
+    infer_package_foreign_keys(p)
+    p.descriptor["resources"].sort(key=lambda x: (x["path"], x["name"]))
+    p.commit()
+    p.save(os.path.join(path, metadata_filename))
 
 
 def infer_metadata(

--- a/src/oemof/tabular/datapackage/building.py
+++ b/src/oemof/tabular/datapackage/building.py
@@ -108,7 +108,9 @@ def map_sequence_profiles_to_resource_name(
     if duplicated_labels:
         # write an error message here
         raise ValueError(
-            f"The following sequences labels are not unique across all sequences files: {', '.join(duplicated_labels)} "
+            f"The following sequences labels are not unique"
+            f" across all sequences files: "
+            f"{', '.join(duplicated_labels)}"
         )
     # map each profile to its resource name
     sequences_mapping = {

--- a/src/oemof/tabular/examples/datapackages/dispatch/datapackage.json
+++ b/src/oemof/tabular/examples/datapackages/dispatch/datapackage.json
@@ -1,6 +1,6 @@
 {
     "profile": "tabular-data-package",
-    "name": "oemof-tabular-dispatch-example",
+    "name": "dispatch-example",
     "oemof_tabular_version": "0.0.6dev",
     "resources": [
         {

--- a/src/oemof/tabular/examples/datapackages/dispatch/scripts/infer.py
+++ b/src/oemof/tabular/examples/datapackages/dispatch/scripts/infer.py
@@ -11,7 +11,7 @@ if "kwargs" not in locals():
     kwargs = {}
 
 building.infer_metadata(
-    package_name="oemof-tabular-dispatch-example",
+    package_name="dispatch-example",
     foreign_keys={
         "bus": ["volatile", "dispatchable", "storage", "load"],
         "profile": ["load", "volatile"],

--- a/src/oemof/tabular/examples/datapackages/dispatch_multi_period/datapackage.json
+++ b/src/oemof/tabular/examples/datapackages/dispatch_multi_period/datapackage.json
@@ -1,6 +1,6 @@
 {
     "profile": "tabular-data-package",
-    "name": "oemof-tabular-dispatch-example",
+    "name": "dispatch_multi_period-example",
     "oemof_tabular_version": "0.0.6dev",
     "resources": [
         {
@@ -380,6 +380,36 @@
             }
         },
         {
+            "path": "data/periods/periods.csv",
+            "profile": "tabular-data-resource",
+            "name": "periods",
+            "format": "csv",
+            "mediatype": "text/csv",
+            "encoding": "utf-8",
+            "schema": {
+                "fields": [
+                    {
+                        "name": "timeindex",
+                        "type": "datetime",
+                        "format": "default"
+                    },
+                    {
+                        "name": "periods",
+                        "type": "integer",
+                        "format": "default"
+                    },
+                    {
+                        "name": "timeincrement",
+                        "type": "integer",
+                        "format": "default"
+                    }
+                ],
+                "missingValues": [
+                    ""
+                ]
+            }
+        },
+        {
             "path": "data/sequences/load_profile.csv",
             "profile": "tabular-data-resource",
             "name": "load_profile",
@@ -425,36 +455,6 @@
                     },
                     {
                         "name": "pv-profile",
-                        "type": "integer",
-                        "format": "default"
-                    }
-                ],
-                "missingValues": [
-                    ""
-                ]
-            }
-        },
-        {
-            "path": "data/periods/periods.csv",
-            "profile": "tabular-data-resource",
-            "name": "periods",
-            "format": "csv",
-            "mediatype": "text/csv",
-            "encoding": "utf-8",
-            "schema": {
-                "fields": [
-                    {
-                        "name": "timeindex",
-                        "type": "datetime",
-                        "format": "default"
-                    },
-                    {
-                        "name": "periods",
-                        "type": "integer",
-                        "format": "default"
-                    },
-                    {
-                        "name": "timeincrement",
                         "type": "integer",
                         "format": "default"
                     }

--- a/src/oemof/tabular/examples/datapackages/dispatch_multi_period/scripts/infer.py
+++ b/src/oemof/tabular/examples/datapackages/dispatch_multi_period/scripts/infer.py
@@ -11,7 +11,7 @@ if "kwargs" not in locals():
     kwargs = {}
 
 building.infer_metadata(
-    package_name="oemof-tabular-dispatch-example",
+    package_name="dispatch_multi_period-example",
     foreign_keys={
         "bus": ["volatile", "dispatchable", "storage", "load"],
         "profile": ["load", "volatile"],

--- a/src/oemof/tabular/examples/datapackages/dispatch_multi_period_periodic_values/datapackage.json
+++ b/src/oemof/tabular/examples/datapackages/dispatch_multi_period_periodic_values/datapackage.json
@@ -1,6 +1,6 @@
 {
     "profile": "tabular-data-package",
-    "name": "oemof-tabular-dispatch-example",
+    "name": "dispatch_multi_period_periodic_values-example",
     "oemof_tabular_version": "0.0.6dev",
     "resources": [
         {
@@ -380,6 +380,36 @@
             }
         },
         {
+            "path": "data/periods/periods.csv",
+            "profile": "tabular-data-resource",
+            "name": "periods",
+            "format": "csv",
+            "mediatype": "text/csv",
+            "encoding": "utf-8",
+            "schema": {
+                "fields": [
+                    {
+                        "name": "timeindex",
+                        "type": "datetime",
+                        "format": "default"
+                    },
+                    {
+                        "name": "periods",
+                        "type": "integer",
+                        "format": "default"
+                    },
+                    {
+                        "name": "timeincrement",
+                        "type": "integer",
+                        "format": "default"
+                    }
+                ],
+                "missingValues": [
+                    ""
+                ]
+            }
+        },
+        {
             "path": "data/sequences/load_profile.csv",
             "profile": "tabular-data-resource",
             "name": "load_profile",
@@ -425,36 +455,6 @@
                     },
                     {
                         "name": "pv-profile",
-                        "type": "integer",
-                        "format": "default"
-                    }
-                ],
-                "missingValues": [
-                    ""
-                ]
-            }
-        },
-        {
-            "path": "data/periods/periods.csv",
-            "profile": "tabular-data-resource",
-            "name": "periods",
-            "format": "csv",
-            "mediatype": "text/csv",
-            "encoding": "utf-8",
-            "schema": {
-                "fields": [
-                    {
-                        "name": "timeindex",
-                        "type": "datetime",
-                        "format": "default"
-                    },
-                    {
-                        "name": "periods",
-                        "type": "integer",
-                        "format": "default"
-                    },
-                    {
-                        "name": "timeincrement",
                         "type": "integer",
                         "format": "default"
                     }

--- a/src/oemof/tabular/examples/datapackages/dispatch_multi_period_periodic_values/scripts/infer.py
+++ b/src/oemof/tabular/examples/datapackages/dispatch_multi_period_periodic_values/scripts/infer.py
@@ -11,7 +11,7 @@ if "kwargs" not in locals():
     kwargs = {}
 
 building.infer_metadata(
-    package_name="oemof-tabular-dispatch-example",
+    package_name="dispatch_multi_period_periodic_values-example",
     foreign_keys={
         "bus": ["volatile", "dispatchable", "storage", "load"],
         "profile": ["load", "volatile"],

--- a/src/oemof/tabular/examples/datapackages/emission_constraint/datapackage.json
+++ b/src/oemof/tabular/examples/datapackages/emission_constraint/datapackage.json
@@ -1,8 +1,43 @@
 {
     "profile": "tabular-data-package",
-    "name": "oemof-tabular-dispatch-example",
+    "name": "emission_constraint-example",
     "oemof_tabular_version": "0.0.6dev",
     "resources": [
+        {
+            "path": "data/constraints/emission_constraint.csv",
+            "profile": "tabular-data-resource",
+            "name": "emission_constraint",
+            "format": "csv",
+            "mediatype": "text/csv",
+            "encoding": "utf-8",
+            "schema": {
+                "fields": [
+                    {
+                        "name": "name",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "type",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "limit",
+                        "type": "integer",
+                        "format": "default"
+                    },
+                    {
+                        "name": "keyword",
+                        "type": "string",
+                        "format": "default"
+                    }
+                ],
+                "missingValues": [
+                    ""
+                ]
+            }
+        },
         {
             "path": "data/elements/bus.csv",
             "profile": "tabular-data-resource",
@@ -394,41 +429,6 @@
                     {
                         "name": "wind-profile",
                         "type": "number",
-                        "format": "default"
-                    }
-                ],
-                "missingValues": [
-                    ""
-                ]
-            }
-        },
-        {
-            "path": "data/constraints/emission_constraint.csv",
-            "profile": "tabular-data-resource",
-            "name": "emission_constraint",
-            "format": "csv",
-            "mediatype": "text/csv",
-            "encoding": "utf-8",
-            "schema": {
-                "fields": [
-                    {
-                        "name": "name",
-                        "type": "string",
-                        "format": "default"
-                    },
-                    {
-                        "name": "type",
-                        "type": "string",
-                        "format": "default"
-                    },
-                    {
-                        "name": "limit",
-                        "type": "integer",
-                        "format": "default"
-                    },
-                    {
-                        "name": "keyword",
-                        "type": "string",
                         "format": "default"
                     }
                 ],

--- a/src/oemof/tabular/examples/datapackages/emission_constraint/scripts/infer.py
+++ b/src/oemof/tabular/examples/datapackages/emission_constraint/scripts/infer.py
@@ -12,7 +12,7 @@ if "kwargs" not in locals():
 
 
 building.infer_metadata(
-    package_name="oemof-tabular-dispatch-example",
+    package_name="emission_constraint-example",
     foreign_keys={
         "bus": ["volatile", "dispatchable", "storage", "load", "excess"],
         "profile": ["load", "volatile"],

--- a/src/oemof/tabular/examples/datapackages/foreignkeys/datapackage.json
+++ b/src/oemof/tabular/examples/datapackages/foreignkeys/datapackage.json
@@ -1,6 +1,6 @@
 {
     "profile": "tabular-data-package",
-    "name": "oemof-tabular-foreignkeys-examples",
+    "name": "foreignkeys-example",
     "oemof_tabular_version": "0.0.6dev",
     "resources": [
         {
@@ -113,15 +113,15 @@
                         }
                     },
                     {
-                        "fields": "marginal_cost",
-                        "reference": {
-                            "resource": "marginal_cost_profile"
-                        }
-                    },
-                    {
                         "fields": "profile",
                         "reference": {
                             "resource": "component_profile"
+                        }
+                    },
+                    {
+                        "fields": "marginal_cost",
+                        "reference": {
+                            "resource": "marginal_cost_profile"
                         }
                     }
                 ]

--- a/src/oemof/tabular/examples/datapackages/foreignkeys/datapackage.json
+++ b/src/oemof/tabular/examples/datapackages/foreignkeys/datapackage.json
@@ -113,15 +113,15 @@
                         }
                     },
                     {
-                        "fields": "profile",
-                        "reference": {
-                            "resource": "component_profile"
-                        }
-                    },
-                    {
                         "fields": "marginal_cost",
                         "reference": {
                             "resource": "marginal_cost_profile"
+                        }
+                    },
+                    {
+                        "fields": "profile",
+                        "reference": {
+                            "resource": "component_profile"
                         }
                     }
                 ]

--- a/src/oemof/tabular/examples/datapackages/foreignkeys/scripts/infer.py
+++ b/src/oemof/tabular/examples/datapackages/foreignkeys/scripts/infer.py
@@ -11,7 +11,7 @@ if "kwargs" not in locals():
     kwargs = {}
 
 building.infer_metadata(
-    package_name="oemof-tabular-foreignkeys-examples",
+    package_name="foreignkeys-example",
     foreign_keys={
         "bus": ["component"],
         "profile": ["component"],

--- a/src/oemof/tabular/examples/datapackages/investment/datapackage.json
+++ b/src/oemof/tabular/examples/datapackages/investment/datapackage.json
@@ -1,6 +1,6 @@
 {
     "profile": "tabular-data-package",
-    "name": "renpass-invest-example",
+    "name": "investment-example",
     "oemof_tabular_version": "0.0.6dev",
     "resources": [
         {

--- a/src/oemof/tabular/examples/datapackages/investment/scripts/infer.py
+++ b/src/oemof/tabular/examples/datapackages/investment/scripts/infer.py
@@ -6,7 +6,7 @@ if "kwargs" not in locals():
     kwargs = {}
 
 building.infer_metadata(
-    package_name="renpass-invest-example",
+    package_name="investment-example",
     foreign_keys={
         "bus": [
             "volatile",

--- a/src/oemof/tabular/examples/datapackages/investment_multi_period/datapackage.json
+++ b/src/oemof/tabular/examples/datapackages/investment_multi_period/datapackage.json
@@ -1,6 +1,6 @@
 {
     "profile": "tabular-data-package",
-    "name": "renpass-invest-example",
+    "name": "investment_multi_period-example",
     "oemof_tabular_version": "0.0.6dev",
     "resources": [
         {
@@ -562,6 +562,36 @@
             }
         },
         {
+            "path": "data/periods/periods.csv",
+            "profile": "tabular-data-resource",
+            "name": "periods",
+            "format": "csv",
+            "mediatype": "text/csv",
+            "encoding": "utf-8",
+            "schema": {
+                "fields": [
+                    {
+                        "name": "timeindex",
+                        "type": "datetime",
+                        "format": "default"
+                    },
+                    {
+                        "name": "periods",
+                        "type": "integer",
+                        "format": "default"
+                    },
+                    {
+                        "name": "timeincrement",
+                        "type": "integer",
+                        "format": "default"
+                    }
+                ],
+                "missingValues": [
+                    ""
+                ]
+            }
+        },
+        {
             "path": "data/sequences/capacity_cost_profile.csv",
             "profile": "tabular-data-resource",
             "name": "capacity_cost_profile",
@@ -633,36 +663,6 @@
                     {
                         "name": "wind-profile",
                         "type": "number",
-                        "format": "default"
-                    }
-                ],
-                "missingValues": [
-                    ""
-                ]
-            }
-        },
-        {
-            "path": "data/periods/periods.csv",
-            "profile": "tabular-data-resource",
-            "name": "periods",
-            "format": "csv",
-            "mediatype": "text/csv",
-            "encoding": "utf-8",
-            "schema": {
-                "fields": [
-                    {
-                        "name": "timeindex",
-                        "type": "datetime",
-                        "format": "default"
-                    },
-                    {
-                        "name": "periods",
-                        "type": "integer",
-                        "format": "default"
-                    },
-                    {
-                        "name": "timeincrement",
-                        "type": "integer",
                         "format": "default"
                     }
                 ],

--- a/src/oemof/tabular/examples/datapackages/investment_multi_period/scripts/infer.py
+++ b/src/oemof/tabular/examples/datapackages/investment_multi_period/scripts/infer.py
@@ -6,7 +6,7 @@ if "kwargs" not in locals():
     kwargs = {}
 
 building.infer_metadata(
-    package_name="renpass-invest-example",
+    package_name="investment_multi_period-example",
     foreign_keys={
         "bus": [
             "volatile",

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -142,5 +142,5 @@ def test_custom_foreign_keys(monkeypatch):
             / "datapackages"
             / "foreignkeys"
         ),
-        package_name="oemof-tabular-foreignkeys-examples",
+        package_name="foreignkeys-example",
     )


### PR DESCRIPTION
# Description

The function infer_metadata_from_data can be run on a datapackage where only the data/elements and data/sequences have been defined by a user and will generate automatically the datapackage.json file containing the metadata.

## Type of change

Please tick or delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

Please tick or delete options that are not relevant.

- [x] New and adjusted code is formatted using the `pre-commit` hooks
 --> I couldn't get the pre-commit `local` tagged object to run, it told me `isort` is unknown command even after I pip installed it ....
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] existing unit tests pass locally with my changes
- [x] I have added new features/fixes to the [CHANGELOG](https://github.com/oemof/oemof-tabular/tree/dev/CHANGELOG.rst)
- [x] I have added my name to [AUTHORS]((https://github.com/oemof/oemof-tabular/tree/dev/AUTHORS.rst)
)
