### PR TITLE
fix/postprocessing-multi-index-error

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,8 @@ Features
 
 Fixes
 
+* MultiIndexError in postprocessing if more than 2 oemof nodes are given `#174 <https://github.com/oemof/oemof-tabular/issues/174>`_
+
 
 0.0.5 Patch Release - Miraculous Mary (2024-02-23)
 -----------------------------------------------------

--- a/src/oemof/tabular/postprocessing/core.py
+++ b/src/oemof/tabular/postprocessing/core.py
@@ -106,6 +106,8 @@ class Calculator:
         for key, series in data.items():
             if series.empty:
                 continue
+            if len(key) != 2:
+                continue
             if data_key == "period_scalars":
                 series = series.transpose()
             mindex = pd.MultiIndex.from_tuples(


### PR DESCRIPTION
Closes #174

Neglects oemof keys if more than 2 nodes are given (input and output)