### PR TITLE
Fix: requires numpy <2.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -75,6 +75,7 @@ setup(
         "oemof.network==0.5.0a4",  # Temporal fix due to braking changes in 0.5.1
         "paramiko",
         "toml",
+        "numpy<2.0.0",
     ],
     extras_require={
         "cli": ["click"],

--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,7 @@ setup(
         "oemof.network==0.5.0a4",  # Temporal fix due to braking changes in 0.5.1
         "paramiko",
         "toml",
-        "numpy<2.0.0",
+        "numpy<2.0.0",  # To be deleted with higher oemof.solph version
     ],
     extras_require={
         "cli": ["click"],


### PR DESCRIPTION
Fix for error:

AttributeError: `np.float_` was removed in the NumPy 2.0 release. Use `np.float64` instead.