### PR TITLE
Make carrier attribute optional

### DIFF
--- a/src/oemof/tabular/datapackage/reading.py
+++ b/src/oemof/tabular/datapackage/reading.py
@@ -100,6 +100,9 @@ def read_facade(
                 )
             )
         )
+    # This is to avoid an error
+    if "carrier" not in facade:
+        facade["carrier"] = ""
     instance = create(mapping, facade, facade)
     facades[facade["name"]] = instance
     return instance

--- a/src/oemof/tabular/facades/conversion.py
+++ b/src/oemof/tabular/facades/conversion.py
@@ -1,4 +1,5 @@
 from dataclasses import field
+from typing import Optional
 
 from oemof.solph._plumbing import sequence
 from oemof.solph.buses import Bus
@@ -81,9 +82,9 @@ class Conversion(Converter, Facade):
 
     to_bus: Bus
 
-    carrier: str
-
     tech: str
+
+    carrier: Optional[str] = None
 
     capacity: float = None
 


### PR DESCRIPTION
# Description

I noticed that carrier was set at the component level and should be explicitly set at bus level in case of multi-input/multi-output components in https://github.com/rl-institut/oemof-tabular-plugins/issues/26 otherwise it leads to logical problems that a component has one carrier assigned although it deals with multiple carriers. This is needed for book-keeping of energy flows from different sectors.

It is possible without any changes to assign a carrier column to the `bus.csv` resource, however it is not possible to not have a `carrier` column in resources based on Facades which have `carrier` as an attribute.

I experimented and saw that the fact that the `carrier` attribute is required in the definition of the facades. It throws an error [at this line](https://github.com/oemof/oemof-tabular/blob/ba77ec17b56b491251ac1eb4f2ed048241666684/src/oemof/tabular/datapackage/reading.py#L103) if I try to instantiate a facade without providing a value for the `carrier` attribute.

Fixes #[oemof-tabular-plugins/issues/26](https://github.com/rl-institut/oemof-tabular-plugins/issues/26)

## Type of change

Right now I outline two suggestions in the two commits for discussion purposes, I will then reset the commits and implement an approved solution.

Suggestion 1:
Always provide carrier as an empty string if "carrier" not found in the kwargs to the facade. This is working well and is a two-liner fix but it is not elegant.

Suggestion 2:
Make carrier attribute optional and with a default value. This is more elegant but we need to change that in all facades


Please tick or delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

Please tick or delete options that are not relevant.

- [x] New and adjusted code is formatted using the `pre-commit` hooks
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
      Existing tests do not pass locally on latest `dev` but they pass online
- [ ] I have added new features/fixes to the [CHANGELOG](https://github.com/oemof/oemof-tabular/tree/dev/CHANGELOG.rst)
- [x] I have added my name to [AUTHORS]((https://github.com/oemof/oemof-tabular/tree/dev/AUTHORS.rst)
)
