### PR TITLE
Naming of emission buses more open

### DIFF
--- a/src/oemof/tabular/examples/datapackages/GHG/data/elements/bus.csv
+++ b/src/oemof/tabular/examples/datapackages/GHG/data/elements/bus.csv
@@ -1,6 +1,6 @@
 name;type;balanced
-co2;bus;false
-ch4;bus;false
-n2o;bus;false
+emi_co2;bus;false
+emi_ch4;bus;false
+emi_n2o;bus;false
 el_bus;bus;true
 gas_bus;bus;true

--- a/src/oemof/tabular/examples/datapackages/GHG/data/elements/commodityGHG_import.csv
+++ b/src/oemof/tabular/examples/datapackages/GHG/data/elements/commodityGHG_import.csv
@@ -1,3 +1,3 @@
-name;type;carrier;amount;bus;emission_bus_0;marginal_cost;output_parameters;emission_factor_co2
-green_gas_import;commodity_ghg;gas;300;gas_bus;co2;20;{"max": [1, 1, 1]};-56
-fossile_gas_import;commodity_ghg;gas;200;gas_bus;co2;10;{"max": [1, 0, 0]};56
+name;type;carrier;amount;bus;emission_bus_0;marginal_cost;output_parameters;emission_factor_emi_co2
+green_gas_import;commodity_ghg;gas;300;gas_bus;emi_co2;20;{"max": [1, 1, 1]};-56
+fossile_gas_import;commodity_ghg;gas;200;gas_bus;emi_co2;10;{"max": [1, 0, 0]};56

--- a/src/oemof/tabular/examples/datapackages/GHG/data/elements/conversionGHG.csv
+++ b/src/oemof/tabular/examples/datapackages/GHG/data/elements/conversionGHG.csv
@@ -1,2 +1,2 @@
-name;type;carrier;tech;capacity;from_bus;to_bus;emission_bus_0;emission_bus_1;emission_bus_2;marginal_cost;efficiency;emission_factor_co2;emission_factor_ch4;emission_factor_n2o
-gtGHG;conversion_ghg;electricity;gt;300;gas_bus;el_bus;co2;ch4;n2o;10;0.5;56;0.4;0.017
+name;type;carrier;tech;capacity;from_bus;to_bus;emission_bus_0;emission_bus_1;emission_bus_2;marginal_cost;efficiency;emission_factor_emi_co2;emission_factor_emi_ch4;emission_factor_emi_n2o
+gtGHG;conversion_ghg;electricity;gt;300;gas_bus;el_bus;emi_co2;emi_ch4;emi_n2o;10;0.5;56;0.4;0.017

--- a/src/oemof/tabular/examples/datapackages/GHG/datapackage.json
+++ b/src/oemof/tabular/examples/datapackages/GHG/datapackage.json
@@ -105,17 +105,17 @@
                         "format": "default"
                     },
                     {
-                        "name": "emission_factor_co2",
+                        "name": "emission_factor_emi_co2",
                         "type": "number",
                         "format": "default"
                     },
                     {
-                        "name": "emission_factor_ch4",
+                        "name": "emission_factor_emi_ch4",
                         "type": "number",
                         "format": "default"
                     },
                     {
-                        "name": "emission_factor_n2o",
+                        "name": "emission_factor_emi_n2o",
                         "type": "number",
                         "format": "default"
                     }
@@ -213,7 +213,7 @@
                         "format": "default"
                     },
                     {
-                        "name": "emission_factor_co2",
+                        "name": "emission_factor_emi_co2",
                         "type": "number",
                         "format": "default"
                     }

--- a/src/oemof/tabular/facades/commodity_ghg.py
+++ b/src/oemof/tabular/facades/commodity_ghg.py
@@ -97,7 +97,7 @@ class CommodityGHG(Commodity):
         emission_factors = {}
         for key, value in list(kwargs.items()):
             if key.startswith("emission_factor"):
-                bus_label = key.split("_")[-1]
+                bus_label = key.removeprefix("emission_factor_")
                 try:
                     bus = [
                         bus

--- a/src/oemof/tabular/facades/conversion_ghg.py
+++ b/src/oemof/tabular/facades/conversion_ghg.py
@@ -111,7 +111,7 @@ class ConversionGHG(Conversion):
         """Adds emission factors as `conversion_factors"""
         for key, value in list(kwargs.items()):
             if key.startswith("emission_factor"):
-                bus_label = key.split("_")[-1]
+                bus_label = key.removeprefix("emission_factor_")
                 try:
                     bus = [
                         bus


### PR DESCRIPTION
# Description

A small change in the code of GHG facades. Now the names of emission buses can be chosen freely. Before you could not use underscores. 

