### PR TITLE
Update datapackage version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10"]
+        python-version: ["3.13"]
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,8 @@ Features
 Fixes
 
 * MultiIndexError in postprocessing if more than 2 oemof nodes are given `#174 <https://github.com/oemof/oemof-tabular/issues/174>`_
+* Updated dependencies for datapackage and tableschema
+* Error due to "fake" foreign keys in datapackage resources
 
 
 0.0.5 Patch Release - Miraculous Mary (2024-02-23)

--- a/setup.py
+++ b/setup.py
@@ -65,8 +65,8 @@ setup(
     ],
     python_requires=">=3.9, <3.14",
     install_requires=[
-        "datapackage==1.15.4",
-        "tableschema==1.21.0",  # newer versions (v1.8.0 and up) fail!
+        "datapackage>=1.5.1",
+        "tableschema>=1.7.4",
         # "oemof.solph>=0.5.1",
         # Upcomming upgrade to solph 0.5.2 postponed due to many changes necessary for implementing
         # explicit arguments and upgrade to network 0.5.1

--- a/setup.py
+++ b/setup.py
@@ -65,8 +65,8 @@ setup(
     ],
     python_requires=">=3.9, <3.11",
     install_requires=[
-        "datapackage==1.5.1",
-        "tableschema==1.7.4",  # newer versions (v1.8.0 and up) fail!
+        "datapackage==1.15.4",
+        "tableschema==1.21.0",  # newer versions (v1.8.0 and up) fail!
         # "oemof.solph>=0.5.1",
         # Upcomming upgrade to solph 0.5.2 postponed due to many changes necessary for implementing
         # explicit arguments and upgrade to network 0.5.1

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ setup(
     keywords=[
         # eg: 'keyword1', 'keyword2', 'keyword3',
     ],
-    python_requires=">=3.9, <3.11",
+    python_requires=">=3.9, <3.14",
     install_requires=[
         "datapackage==1.15.4",
         "tableschema==1.21.0",  # newer versions (v1.8.0 and up) fail!

--- a/src/oemof/tabular/datapackage/aggregation.py
+++ b/src/oemof/tabular/datapackage/aggregation.py
@@ -88,9 +88,9 @@ def temporal_skip(datapackage, n, path="/tmp", name=None, *args):
     r = Resource({"path": "data/temporal.csv"})
     r.infer()
 
-    r.descriptor["description"] = (
-        "Temporal selection based on skipped timesteps. Skipped n={}".format(n)
-    )
+    r.descriptor[
+        "description"
+    ] = "Temporal selection based on skipped timesteps. Skipped n={}".format(n)
 
     # Update meta-data of copied package
     cp = Package("datapackage.json")
@@ -212,9 +212,9 @@ def temporal_clustering(datapackage, n, path="/tmp", how="daily"):
     r = Resource({"path": "data/temporal.csv"})
     r.infer()
     # TODO: Add meta-data description
-    r.descriptor["description"] = (
-        "Temporal selection based on hierachical clustering..."
-    )
+    r.descriptor[
+        "description"
+    ] = "Temporal selection based on hierachical clustering..."
 
     # Update meta-data of copied package
     cp = Package("datapackage.json")

--- a/src/oemof/tabular/datapackage/building.py
+++ b/src/oemof/tabular/datapackage/building.py
@@ -148,7 +148,6 @@ def infer_resource_foreign_keys(resource, sequences_profiles_to_resource):
     for field in r.schema.fields:
         if field.type == "string":
             for potential_fk in data[field.name].dropna().unique():
-
                 if potential_fk in sequences_profiles_to_resource:
                     # this is actually a wrong format and should be
                     # with a "fields" field under the "reference" fields

--- a/src/oemof/tabular/datapackage/reading.py
+++ b/src/oemof/tabular/datapackage/reading.py
@@ -12,6 +12,7 @@ along with how to use the functions in this module.
 
 import collections.abc as cabc
 import json
+import os
 import re
 import typing
 import warnings
@@ -149,7 +150,7 @@ def deserialize_energy_system(cls, path, typemap={}, attributemap={}):
             for fk in resource["schema"]["foreignKeys"]
             if fk["reference"]["resource"] == "bus"
         ]
-    datapackage_folder = path[:-17]  # Remove "/datapackage.json" form path
+    datapackage_folder = os.path.dirname(path)  # Remove "/datapackage.json" form path
     package = dp.Package(datapackage_json, base_path=datapackage_folder)
 
     # This is necessary because before reading a resource for the first

--- a/src/oemof/tabular/datapackage/reading.py
+++ b/src/oemof/tabular/datapackage/reading.py
@@ -137,9 +137,18 @@ def deserialize_energy_system(cls, path, typemap={}, attributemap={}):
         if "foreignKeys" not in resource["schema"]:
             continue
         # Busses are real ForeignKeys and can stay in ForeignKeys field
-        # Foreign Keys to sequences must be extracted and handled separately from datapackage
-        sequence_foreign_keys[resource["name"]] = [fk for fk in resource["schema"]["foreignKeys"] if fk["reference"]["resource"] != "bus"]
-        resource["schema"]["foreignKeys"] = [fk for fk in resource["schema"]["foreignKeys"] if fk["reference"]["resource"] == "bus"]
+        # Foreign Keys to sequences must be extracted and handled separately
+        # from datapackage
+        sequence_foreign_keys[resource["name"]] = [
+            fk
+            for fk in resource["schema"]["foreignKeys"]
+            if fk["reference"]["resource"] != "bus"
+        ]
+        resource["schema"]["foreignKeys"] = [
+            fk
+            for fk in resource["schema"]["foreignKeys"]
+            if fk["reference"]["resource"] == "bus"
+        ]
     datapackage_folder = path[:-17]  # Remove "/datapackage.json" form path
     package = dp.Package(datapackage_json, base_path=datapackage_folder)
 
@@ -574,7 +583,8 @@ def deserialize_energy_system(cls, path, typemap={}, attributemap={}):
 
             foreign_keys = {
                 fk["fields"]: fk["reference"]
-                for fk in r.descriptor["schema"].get("foreignKeys", []) + sequence_foreign_keys[r.name]
+                for fk in r.descriptor["schema"].get("foreignKeys", [])
+                + sequence_foreign_keys[r.name]
             }
 
             for facade in facade_data:

--- a/src/oemof/tabular/datapackage/reading.py
+++ b/src/oemof/tabular/datapackage/reading.py
@@ -128,7 +128,21 @@ def deserialize_energy_system(cls, path, typemap={}, attributemap={}):
         if value.get("name") is None:
             attributemap[k]["name"] = "label"
 
-    package = dp.Package(path)
+    # Extract ForeignKeys from datapackage upfront in order to avoid FK-Errors
+    with open(path, "r") as f:
+        datapackage_json = json.load(f)
+
+    sequence_foreign_keys = {}
+    for resource in datapackage_json["resources"]:
+        if "foreignKeys" not in resource["schema"]:
+            continue
+        # Busses are real ForeignKeys and can stay in ForeignKeys field
+        # Foreign Keys to sequences must be extracted and handled separately from datapackage
+        sequence_foreign_keys[resource["name"]] = [fk for fk in resource["schema"]["foreignKeys"] if fk["reference"]["resource"] != "bus"]
+        resource["schema"]["foreignKeys"] = [fk for fk in resource["schema"]["foreignKeys"] if fk["reference"]["resource"] == "bus"]
+    datapackage_folder = path[:-17]  # Remove "/datapackage.json" form path
+    package = dp.Package(datapackage_json, base_path=datapackage_folder)
+
     # This is necessary because before reading a resource for the first
     # time its `headers` attribute is `None`.
     for r in package.resources:
@@ -560,7 +574,7 @@ def deserialize_energy_system(cls, path, typemap={}, attributemap={}):
 
             foreign_keys = {
                 fk["fields"]: fk["reference"]
-                for fk in r.descriptor["schema"].get("foreignKeys", ())
+                for fk in r.descriptor["schema"].get("foreignKeys", []) + sequence_foreign_keys[r.name]
             }
 
             for facade in facade_data:

--- a/src/oemof/tabular/examples/datapackages/investment/data/elements/storage.csv
+++ b/src/oemof/tabular/examples/datapackages/investment/data/elements/storage.csv
@@ -1,2 +1,2 @@
-name;carrier;tech;storage_capacity;capacity;capacity_cost;invest_relation_output_capacity;invest_relation_input_output;expandable;type;bus;tech
-el-storage;lithium;battery;100;0;10;0.2;1;true;storage;bus0;battery
+name;carrier;tech;storage_capacity;capacity;capacity_cost;invest_relation_output_capacity;invest_relation_input_output;expandable;type;bus
+el-storage;lithium;battery;100;0;10;0.2;1;true;storage;bus0

--- a/src/oemof/tabular/examples/datapackages/investment/datapackage.json
+++ b/src/oemof/tabular/examples/datapackages/investment/datapackage.json
@@ -493,11 +493,6 @@
                         "name": "bus",
                         "type": "string",
                         "format": "default"
-                    },
-                    {
-                        "name": "tech",
-                        "type": "string",
-                        "format": "default"
                     }
                 ],
                 "missingValues": [

--- a/src/oemof/tabular/examples/datapackages/investment_multi_period/data/elements/storage.csv
+++ b/src/oemof/tabular/examples/datapackages/investment_multi_period/data/elements/storage.csv
@@ -1,2 +1,2 @@
-name;carrier;tech;storage_capacity;capacity;capacity_cost;invest_relation_output_capacity;invest_relation_input_output;expandable;type;bus;tech;lifetime;age
-el-storage;lithium;battery;100;0;10;0.2;1;true;storage;bus0;battery;20;0
+name;carrier;tech;storage_capacity;capacity;capacity_cost;invest_relation_output_capacity;invest_relation_input_output;expandable;type;bus;lifetime;age
+el-storage;lithium;battery;100;0;10;0.2;1;true;storage;bus0;20;0

--- a/src/oemof/tabular/examples/datapackages/investment_multi_period/datapackage.json
+++ b/src/oemof/tabular/examples/datapackages/investment_multi_period/datapackage.json
@@ -531,11 +531,6 @@
                         "format": "default"
                     },
                     {
-                        "name": "tech",
-                        "type": "string",
-                        "format": "default"
-                    },
-                    {
                         "name": "lifetime",
                         "type": "integer",
                         "format": "default"

--- a/src/oemof/tabular/facades/commodity_ghg.py
+++ b/src/oemof/tabular/facades/commodity_ghg.py
@@ -69,7 +69,6 @@ class CommodityGHG(Commodity):
     """
 
     def __init__(self, **kwargs):
-
         super().__init__(
             **kwargs,
         )

--- a/tests/_files/lp_files/extraction_investment_brown_field.lp
+++ b/tests/_files/lp_files/extraction_investment_brown_field.lp
@@ -1,6 +1,6 @@
 \* Source Pyomo model name=Model *\
 
-min
+min 
 objective:
 +50 InvestmentFlowBlock_invest(extraction_electricity_0)
 +0.6 flow(gas_extraction_0_0)
@@ -8,6 +8,18 @@ objective:
 +0.6 flow(gas_extraction_0_2)
 
 s.t.
+
+c_e_BusBlock_balance(electricity_0_0)_:
++1 flow(extraction_electricity_0_0)
+= 0
+
+c_e_BusBlock_balance(electricity_0_1)_:
++1 flow(extraction_electricity_0_1)
+= 0
+
+c_e_BusBlock_balance(electricity_0_2)_:
++1 flow(extraction_electricity_0_2)
+= 0
 
 c_e_BusBlock_balance(gas_0_0)_:
 +1 flow(gas_extraction_0_0)
@@ -33,18 +45,6 @@ c_e_BusBlock_balance(heat_0_2)_:
 +1 flow(extraction_heat_0_2)
 = 0
 
-c_e_BusBlock_balance(electricity_0_0)_:
-+1 flow(extraction_electricity_0_0)
-= 0
-
-c_e_BusBlock_balance(electricity_0_1)_:
-+1 flow(extraction_electricity_0_1)
-= 0
-
-c_e_BusBlock_balance(electricity_0_2)_:
-+1 flow(extraction_electricity_0_2)
-= 0
-
 c_e_InvestmentFlowBlock_total_rule(extraction_electricity_0)_:
 -1 InvestmentFlowBlock_invest(extraction_electricity_0)
 +1 InvestmentFlowBlock_total(extraction_electricity_0)
@@ -67,47 +67,47 @@ c_u_InvestmentFlowBlock_max(extraction_electricity_0_2)_:
 
 c_e_ExtractionTurbineCHPBlock_input_output_relation(extraction_0_0)_:
 +1 flow(gas_extraction_0_0)
--0.5714285714285713 flow(extraction_heat_0_0)
 -2.0 flow(extraction_electricity_0_0)
-= 0
+-0.5714285714285713 flow(extraction_heat_0_0)
+= 0.0
 
 c_e_ExtractionTurbineCHPBlock_input_output_relation(extraction_0_1)_:
 +1 flow(gas_extraction_0_1)
--0.5714285714285713 flow(extraction_heat_0_1)
 -2.0 flow(extraction_electricity_0_1)
-= 0
+-0.5714285714285713 flow(extraction_heat_0_1)
+= 0.0
 
 c_e_ExtractionTurbineCHPBlock_input_output_relation(extraction_0_2)_:
 +1 flow(gas_extraction_0_2)
--0.5714285714285713 flow(extraction_heat_0_2)
 -2.0 flow(extraction_electricity_0_2)
-= 0
+-0.5714285714285713 flow(extraction_heat_0_2)
+= 0.0
 
 c_u_ExtractionTurbineCHPBlock_out_flow_relation(extraction_0_0)_:
-+1.142857142857143 flow(extraction_heat_0_0)
 -1 flow(extraction_electricity_0_0)
++1.142857142857143 flow(extraction_heat_0_0)
 <= 0
 
 c_u_ExtractionTurbineCHPBlock_out_flow_relation(extraction_0_1)_:
-+1.142857142857143 flow(extraction_heat_0_1)
 -1 flow(extraction_electricity_0_1)
++1.142857142857143 flow(extraction_heat_0_1)
 <= 0
 
 c_u_ExtractionTurbineCHPBlock_out_flow_relation(extraction_0_2)_:
-+1.142857142857143 flow(extraction_heat_0_2)
 -1 flow(extraction_electricity_0_2)
++1.142857142857143 flow(extraction_heat_0_2)
 <= 0
 
 bounds
    0 <= InvestmentFlowBlock_invest(extraction_electricity_0) <= +inf
-   0 <= InvestmentFlowBlock_total(extraction_electricity_0) <= +inf
    0 <= flow(gas_extraction_0_0) <= +inf
    0 <= flow(gas_extraction_0_1) <= +inf
    0 <= flow(gas_extraction_0_2) <= +inf
-   0 <= flow(extraction_heat_0_0) <= +inf
-   0 <= flow(extraction_heat_0_1) <= +inf
-   0 <= flow(extraction_heat_0_2) <= +inf
    0 <= flow(extraction_electricity_0_0) <= +inf
    0 <= flow(extraction_electricity_0_1) <= +inf
    0 <= flow(extraction_electricity_0_2) <= +inf
+   0 <= flow(extraction_heat_0_0) <= +inf
+   0 <= flow(extraction_heat_0_1) <= +inf
+   0 <= flow(extraction_heat_0_2) <= +inf
+   0 <= InvestmentFlowBlock_total(extraction_electricity_0) <= +inf
 end

--- a/tests/_files/lp_files/extraction_investment_green_field.lp
+++ b/tests/_files/lp_files/extraction_investment_green_field.lp
@@ -1,6 +1,6 @@
 \* Source Pyomo model name=Model *\
 
-min
+min 
 objective:
 +50 InvestmentFlowBlock_invest(extraction_electricity_0)
 +0.6 flow(gas_extraction_0_0)
@@ -21,18 +21,6 @@ c_e_BusBlock_balance(gas_0_2)_:
 +1 flow(gas_extraction_0_2)
 = 0
 
-c_e_BusBlock_balance(heat_0_0)_:
-+1 flow(extraction_heat_0_0)
-= 0
-
-c_e_BusBlock_balance(heat_0_1)_:
-+1 flow(extraction_heat_0_1)
-= 0
-
-c_e_BusBlock_balance(heat_0_2)_:
-+1 flow(extraction_heat_0_2)
-= 0
-
 c_e_BusBlock_balance(electricity_0_0)_:
 +1 flow(extraction_electricity_0_0)
 = 0
@@ -43,6 +31,18 @@ c_e_BusBlock_balance(electricity_0_1)_:
 
 c_e_BusBlock_balance(electricity_0_2)_:
 +1 flow(extraction_electricity_0_2)
+= 0
+
+c_e_BusBlock_balance(heat_0_0)_:
++1 flow(extraction_heat_0_0)
+= 0
+
+c_e_BusBlock_balance(heat_0_1)_:
++1 flow(extraction_heat_0_1)
+= 0
+
+c_e_BusBlock_balance(heat_0_2)_:
++1 flow(extraction_heat_0_2)
 = 0
 
 c_e_InvestmentFlowBlock_total_rule(extraction_electricity_0)_:
@@ -67,47 +67,47 @@ c_u_InvestmentFlowBlock_max(extraction_electricity_0_2)_:
 
 c_e_ExtractionTurbineCHPBlock_input_output_relation(extraction_0_0)_:
 +1 flow(gas_extraction_0_0)
--0.5714285714285713 flow(extraction_heat_0_0)
 -2.0 flow(extraction_electricity_0_0)
-= 0
+-0.5714285714285713 flow(extraction_heat_0_0)
+= 0.0
 
 c_e_ExtractionTurbineCHPBlock_input_output_relation(extraction_0_1)_:
 +1 flow(gas_extraction_0_1)
--0.5714285714285713 flow(extraction_heat_0_1)
 -2.0 flow(extraction_electricity_0_1)
-= 0
+-0.5714285714285713 flow(extraction_heat_0_1)
+= 0.0
 
 c_e_ExtractionTurbineCHPBlock_input_output_relation(extraction_0_2)_:
 +1 flow(gas_extraction_0_2)
--0.5714285714285713 flow(extraction_heat_0_2)
 -2.0 flow(extraction_electricity_0_2)
-= 0
+-0.5714285714285713 flow(extraction_heat_0_2)
+= 0.0
 
 c_u_ExtractionTurbineCHPBlock_out_flow_relation(extraction_0_0)_:
-+1.142857142857143 flow(extraction_heat_0_0)
 -1 flow(extraction_electricity_0_0)
++1.142857142857143 flow(extraction_heat_0_0)
 <= 0
 
 c_u_ExtractionTurbineCHPBlock_out_flow_relation(extraction_0_1)_:
-+1.142857142857143 flow(extraction_heat_0_1)
 -1 flow(extraction_electricity_0_1)
++1.142857142857143 flow(extraction_heat_0_1)
 <= 0
 
 c_u_ExtractionTurbineCHPBlock_out_flow_relation(extraction_0_2)_:
-+1.142857142857143 flow(extraction_heat_0_2)
 -1 flow(extraction_electricity_0_2)
++1.142857142857143 flow(extraction_heat_0_2)
 <= 0
 
 bounds
    0 <= InvestmentFlowBlock_invest(extraction_electricity_0) <= +inf
-   0 <= InvestmentFlowBlock_total(extraction_electricity_0) <= +inf
    0 <= flow(gas_extraction_0_0) <= +inf
    0 <= flow(gas_extraction_0_1) <= +inf
    0 <= flow(gas_extraction_0_2) <= +inf
-   0 <= flow(extraction_heat_0_0) <= +inf
-   0 <= flow(extraction_heat_0_1) <= +inf
-   0 <= flow(extraction_heat_0_2) <= +inf
    0 <= flow(extraction_electricity_0_0) <= +inf
    0 <= flow(extraction_electricity_0_1) <= +inf
    0 <= flow(extraction_electricity_0_2) <= +inf
+   0 <= flow(extraction_heat_0_0) <= +inf
+   0 <= flow(extraction_heat_0_1) <= +inf
+   0 <= flow(extraction_heat_0_2) <= +inf
+   0 <= InvestmentFlowBlock_total(extraction_electricity_0) <= +inf
 end

--- a/tests/_files/lp_files/multi-period/extraction_investment_brown_field_multi_period.lp
+++ b/tests/_files/lp_files/multi-period/extraction_investment_brown_field_multi_period.lp
@@ -18,42 +18,6 @@ objective:
 
 s.t.
 
-c_e_BusBlock_balance(electricity_0_0)_:
-+1 flow(extraction_electricity_0_0)
-= 0
-
-c_e_BusBlock_balance(electricity_0_1)_:
-+1 flow(extraction_electricity_0_1)
-= 0
-
-c_e_BusBlock_balance(electricity_0_2)_:
-+1 flow(extraction_electricity_0_2)
-= 0
-
-c_e_BusBlock_balance(electricity_1_3)_:
-+1 flow(extraction_electricity_1_3)
-= 0
-
-c_e_BusBlock_balance(electricity_1_4)_:
-+1 flow(extraction_electricity_1_4)
-= 0
-
-c_e_BusBlock_balance(electricity_1_5)_:
-+1 flow(extraction_electricity_1_5)
-= 0
-
-c_e_BusBlock_balance(electricity_2_6)_:
-+1 flow(extraction_electricity_2_6)
-= 0
-
-c_e_BusBlock_balance(electricity_2_7)_:
-+1 flow(extraction_electricity_2_7)
-= 0
-
-c_e_BusBlock_balance(electricity_2_8)_:
-+1 flow(extraction_electricity_2_8)
-= 0
-
 c_e_BusBlock_balance(gas_0_0)_:
 +1 flow(gas_extraction_0_0)
 = 0
@@ -88,6 +52,42 @@ c_e_BusBlock_balance(gas_2_7)_:
 
 c_e_BusBlock_balance(gas_2_8)_:
 +1 flow(gas_extraction_2_8)
+= 0
+
+c_e_BusBlock_balance(electricity_0_0)_:
++1 flow(extraction_electricity_0_0)
+= 0
+
+c_e_BusBlock_balance(electricity_0_1)_:
++1 flow(extraction_electricity_0_1)
+= 0
+
+c_e_BusBlock_balance(electricity_0_2)_:
++1 flow(extraction_electricity_0_2)
+= 0
+
+c_e_BusBlock_balance(electricity_1_3)_:
++1 flow(extraction_electricity_1_3)
+= 0
+
+c_e_BusBlock_balance(electricity_1_4)_:
++1 flow(extraction_electricity_1_4)
+= 0
+
+c_e_BusBlock_balance(electricity_1_5)_:
++1 flow(extraction_electricity_1_5)
+= 0
+
+c_e_BusBlock_balance(electricity_2_6)_:
++1 flow(extraction_electricity_2_6)
+= 0
+
+c_e_BusBlock_balance(electricity_2_7)_:
++1 flow(extraction_electricity_2_7)
+= 0
+
+c_e_BusBlock_balance(electricity_2_8)_:
++1 flow(extraction_electricity_2_8)
 = 0
 
 c_e_BusBlock_balance(heat_0_0)_:
@@ -171,9 +171,9 @@ c_e_InvestmentFlowBlock_old_rule_exo(extraction_electricity_2)_:
 = 1000
 
 c_e_InvestmentFlowBlock_old_rule(extraction_electricity_0)_:
-+1 InvestmentFlowBlock_old(extraction_electricity_0)
 -1 InvestmentFlowBlock_old_end(extraction_electricity_0)
 -1 InvestmentFlowBlock_old_exo(extraction_electricity_0)
++1 InvestmentFlowBlock_old(extraction_electricity_0)
 = 0
 
 c_e_InvestmentFlowBlock_old_rule(extraction_electricity_1)_:
@@ -237,55 +237,55 @@ c_e_ExtractionTurbineCHPBlock_input_output_relation(extraction_0_0)_:
 +1 flow(gas_extraction_0_0)
 -2.0 flow(extraction_electricity_0_0)
 -0.5714285714285713 flow(extraction_heat_0_0)
-= 0
+= 0.0
 
 c_e_ExtractionTurbineCHPBlock_input_output_relation(extraction_0_1)_:
 +1 flow(gas_extraction_0_1)
 -2.0 flow(extraction_electricity_0_1)
 -0.5714285714285713 flow(extraction_heat_0_1)
-= 0
+= 0.0
 
 c_e_ExtractionTurbineCHPBlock_input_output_relation(extraction_0_2)_:
 +1 flow(gas_extraction_0_2)
 -2.0 flow(extraction_electricity_0_2)
 -0.5714285714285713 flow(extraction_heat_0_2)
-= 0
+= 0.0
 
 c_e_ExtractionTurbineCHPBlock_input_output_relation(extraction_1_3)_:
 +1 flow(gas_extraction_1_3)
 -2.0 flow(extraction_electricity_1_3)
 -0.5714285714285713 flow(extraction_heat_1_3)
-= 0
+= 0.0
 
 c_e_ExtractionTurbineCHPBlock_input_output_relation(extraction_1_4)_:
 +1 flow(gas_extraction_1_4)
 -2.0 flow(extraction_electricity_1_4)
 -0.5714285714285713 flow(extraction_heat_1_4)
-= 0
+= 0.0
 
 c_e_ExtractionTurbineCHPBlock_input_output_relation(extraction_1_5)_:
 +1 flow(gas_extraction_1_5)
 -2.0 flow(extraction_electricity_1_5)
 -0.5714285714285713 flow(extraction_heat_1_5)
-= 0
+= 0.0
 
 c_e_ExtractionTurbineCHPBlock_input_output_relation(extraction_2_6)_:
 +1 flow(gas_extraction_2_6)
 -2.0 flow(extraction_electricity_2_6)
 -0.5714285714285713 flow(extraction_heat_2_6)
-= 0
+= 0.0
 
 c_e_ExtractionTurbineCHPBlock_input_output_relation(extraction_2_7)_:
 +1 flow(gas_extraction_2_7)
 -2.0 flow(extraction_electricity_2_7)
 -0.5714285714285713 flow(extraction_heat_2_7)
-= 0
+= 0.0
 
 c_e_ExtractionTurbineCHPBlock_input_output_relation(extraction_2_8)_:
 +1 flow(gas_extraction_2_8)
 -2.0 flow(extraction_electricity_2_8)
 -0.5714285714285713 flow(extraction_heat_2_8)
-= 0
+= 0.0
 
 c_u_ExtractionTurbineCHPBlock_out_flow_relation(extraction_0_0)_:
 -1 flow(extraction_electricity_0_0)
@@ -366,9 +366,8 @@ bounds
    0 <= flow(extraction_heat_2_8) <= +inf
    0 <= InvestmentFlowBlock_total(extraction_electricity_0) <= +inf
    0 <= InvestmentFlowBlock_total(extraction_electricity_1) <= +inf
-   0 <= InvestmentFlowBlock_total(extraction_electricity_2) <= +inf
-   0 <= InvestmentFlowBlock_old(extraction_electricity_0) <= +inf
    0 <= InvestmentFlowBlock_old(extraction_electricity_1) <= +inf
+   0 <= InvestmentFlowBlock_total(extraction_electricity_2) <= +inf
    0 <= InvestmentFlowBlock_old(extraction_electricity_2) <= +inf
    0 <= InvestmentFlowBlock_old_end(extraction_electricity_0) <= +inf
    0 <= InvestmentFlowBlock_old_end(extraction_electricity_1) <= +inf
@@ -376,4 +375,5 @@ bounds
    0 <= InvestmentFlowBlock_old_exo(extraction_electricity_0) <= +inf
    0 <= InvestmentFlowBlock_old_exo(extraction_electricity_1) <= +inf
    0 <= InvestmentFlowBlock_old_exo(extraction_electricity_2) <= +inf
+   0 <= InvestmentFlowBlock_old(extraction_electricity_0) <= +inf
 end

--- a/tests/_files/lp_files/multi-period/extraction_investment_green_field_multi_period.lp
+++ b/tests/_files/lp_files/multi-period/extraction_investment_green_field_multi_period.lp
@@ -17,42 +17,6 @@ objective:
 
 s.t.
 
-c_e_BusBlock_balance(electricity_0_0)_:
-+1 flow(extraction_electricity_0_0)
-= 0
-
-c_e_BusBlock_balance(electricity_0_1)_:
-+1 flow(extraction_electricity_0_1)
-= 0
-
-c_e_BusBlock_balance(electricity_0_2)_:
-+1 flow(extraction_electricity_0_2)
-= 0
-
-c_e_BusBlock_balance(electricity_1_3)_:
-+1 flow(extraction_electricity_1_3)
-= 0
-
-c_e_BusBlock_balance(electricity_1_4)_:
-+1 flow(extraction_electricity_1_4)
-= 0
-
-c_e_BusBlock_balance(electricity_1_5)_:
-+1 flow(extraction_electricity_1_5)
-= 0
-
-c_e_BusBlock_balance(electricity_2_6)_:
-+1 flow(extraction_electricity_2_6)
-= 0
-
-c_e_BusBlock_balance(electricity_2_7)_:
-+1 flow(extraction_electricity_2_7)
-= 0
-
-c_e_BusBlock_balance(electricity_2_8)_:
-+1 flow(extraction_electricity_2_8)
-= 0
-
 c_e_BusBlock_balance(gas_0_0)_:
 +1 flow(gas_extraction_0_0)
 = 0
@@ -87,6 +51,42 @@ c_e_BusBlock_balance(gas_2_7)_:
 
 c_e_BusBlock_balance(gas_2_8)_:
 +1 flow(gas_extraction_2_8)
+= 0
+
+c_e_BusBlock_balance(electricity_0_0)_:
++1 flow(extraction_electricity_0_0)
+= 0
+
+c_e_BusBlock_balance(electricity_0_1)_:
++1 flow(extraction_electricity_0_1)
+= 0
+
+c_e_BusBlock_balance(electricity_0_2)_:
++1 flow(extraction_electricity_0_2)
+= 0
+
+c_e_BusBlock_balance(electricity_1_3)_:
++1 flow(extraction_electricity_1_3)
+= 0
+
+c_e_BusBlock_balance(electricity_1_4)_:
++1 flow(extraction_electricity_1_4)
+= 0
+
+c_e_BusBlock_balance(electricity_1_5)_:
++1 flow(extraction_electricity_1_5)
+= 0
+
+c_e_BusBlock_balance(electricity_2_6)_:
++1 flow(extraction_electricity_2_6)
+= 0
+
+c_e_BusBlock_balance(electricity_2_7)_:
++1 flow(extraction_electricity_2_7)
+= 0
+
+c_e_BusBlock_balance(electricity_2_8)_:
++1 flow(extraction_electricity_2_8)
 = 0
 
 c_e_BusBlock_balance(heat_0_0)_:
@@ -170,9 +170,9 @@ c_e_InvestmentFlowBlock_old_rule_exo(extraction_electricity_2)_:
 = 0
 
 c_e_InvestmentFlowBlock_old_rule(extraction_electricity_0)_:
-+1 InvestmentFlowBlock_old(extraction_electricity_0)
 -1 InvestmentFlowBlock_old_end(extraction_electricity_0)
 -1 InvestmentFlowBlock_old_exo(extraction_electricity_0)
++1 InvestmentFlowBlock_old(extraction_electricity_0)
 = 0
 
 c_e_InvestmentFlowBlock_old_rule(extraction_electricity_1)_:
@@ -236,55 +236,55 @@ c_e_ExtractionTurbineCHPBlock_input_output_relation(extraction_0_0)_:
 +1 flow(gas_extraction_0_0)
 -2.0 flow(extraction_electricity_0_0)
 -0.5714285714285713 flow(extraction_heat_0_0)
-= 0
+= 0.0
 
 c_e_ExtractionTurbineCHPBlock_input_output_relation(extraction_0_1)_:
 +1 flow(gas_extraction_0_1)
 -2.0 flow(extraction_electricity_0_1)
 -0.5714285714285713 flow(extraction_heat_0_1)
-= 0
+= 0.0
 
 c_e_ExtractionTurbineCHPBlock_input_output_relation(extraction_0_2)_:
 +1 flow(gas_extraction_0_2)
 -2.0 flow(extraction_electricity_0_2)
 -0.5714285714285713 flow(extraction_heat_0_2)
-= 0
+= 0.0
 
 c_e_ExtractionTurbineCHPBlock_input_output_relation(extraction_1_3)_:
 +1 flow(gas_extraction_1_3)
 -2.0 flow(extraction_electricity_1_3)
 -0.5714285714285713 flow(extraction_heat_1_3)
-= 0
+= 0.0
 
 c_e_ExtractionTurbineCHPBlock_input_output_relation(extraction_1_4)_:
 +1 flow(gas_extraction_1_4)
 -2.0 flow(extraction_electricity_1_4)
 -0.5714285714285713 flow(extraction_heat_1_4)
-= 0
+= 0.0
 
 c_e_ExtractionTurbineCHPBlock_input_output_relation(extraction_1_5)_:
 +1 flow(gas_extraction_1_5)
 -2.0 flow(extraction_electricity_1_5)
 -0.5714285714285713 flow(extraction_heat_1_5)
-= 0
+= 0.0
 
 c_e_ExtractionTurbineCHPBlock_input_output_relation(extraction_2_6)_:
 +1 flow(gas_extraction_2_6)
 -2.0 flow(extraction_electricity_2_6)
 -0.5714285714285713 flow(extraction_heat_2_6)
-= 0
+= 0.0
 
 c_e_ExtractionTurbineCHPBlock_input_output_relation(extraction_2_7)_:
 +1 flow(gas_extraction_2_7)
 -2.0 flow(extraction_electricity_2_7)
 -0.5714285714285713 flow(extraction_heat_2_7)
-= 0
+= 0.0
 
 c_e_ExtractionTurbineCHPBlock_input_output_relation(extraction_2_8)_:
 +1 flow(gas_extraction_2_8)
 -2.0 flow(extraction_electricity_2_8)
 -0.5714285714285713 flow(extraction_heat_2_8)
-= 0
+= 0.0
 
 c_u_ExtractionTurbineCHPBlock_out_flow_relation(extraction_0_0)_:
 -1 flow(extraction_electricity_0_0)
@@ -364,9 +364,8 @@ bounds
    0 <= flow(extraction_heat_2_8) <= +inf
    0 <= InvestmentFlowBlock_total(extraction_electricity_0) <= +inf
    0 <= InvestmentFlowBlock_total(extraction_electricity_1) <= +inf
-   0 <= InvestmentFlowBlock_total(extraction_electricity_2) <= +inf
-   0 <= InvestmentFlowBlock_old(extraction_electricity_0) <= +inf
    0 <= InvestmentFlowBlock_old(extraction_electricity_1) <= +inf
+   0 <= InvestmentFlowBlock_total(extraction_electricity_2) <= +inf
    0 <= InvestmentFlowBlock_old(extraction_electricity_2) <= +inf
    0 <= InvestmentFlowBlock_old_end(extraction_electricity_0) <= +inf
    0 <= InvestmentFlowBlock_old_end(extraction_electricity_1) <= +inf
@@ -374,4 +373,5 @@ bounds
    0 <= InvestmentFlowBlock_old_exo(extraction_electricity_0) <= +inf
    0 <= InvestmentFlowBlock_old_exo(extraction_electricity_1) <= +inf
    0 <= InvestmentFlowBlock_old_exo(extraction_electricity_2) <= +inf
+   0 <= InvestmentFlowBlock_old(extraction_electricity_0) <= +inf
 end

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -49,7 +49,9 @@ def normalize_to_positive_results(lines):
             lines[n] = (
                 "-"
                 if lines[n] and lines[n][0] == "+"
-                else "+" if lines[n] else lines[n]
+                else "+"
+                if lines[n]
+                else lines[n]
             ) + lines[n][1:]
         lines[end] = "= " + lines[end][3:]
     return lines

--- a/tests/test_multi_period_constraints.py
+++ b/tests/test_multi_period_constraints.py
@@ -47,7 +47,9 @@ def normalize_to_positive_results(lines):
             lines[n] = (
                 "-"
                 if lines[n] and lines[n][0] == "+"
-                else "+" if lines[n] else lines[n]
+                else "+"
+                if lines[n]
+                else lines[n]
             ) + lines[n][1:]
         lines[end] = "= " + lines[end][3:]
     return lines


### PR DESCRIPTION
# Description

I could fix error due to "fake" foreign keys by extracting them from schema before reading in the datapackage.
When facades are built, the extracted foreign keys pointing to sequences are re-added to foreign keys, so that sequences (profiles etc.) can be connected correctly.
This is a simple workaround, which leaves most code in place and should work out-of-the-box for older and newer environments.
A more general approach as discussed in #74 is favorable, but would break older datapackage and thus is a breaking change.

Had to fix some  LP files where order of lines had changed and fix two datapackages where duplicate columns were present (which is handled differently in newer datapackage version).

Fixes #187 

## Type of change

Please tick or delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

Please tick or delete options that are not relevant.

- [x] New and adjusted code is formatted using the `pre-commit` hooks
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] If new packages are needed, I added them the [setup.py](https://github.com/oemof/oemof-tabular/blob/dev/setup.py#L67-L80)
- [x] I have added new features/fixes to the [CHANGELOG](https://github.com/oemof/oemof-tabular/tree/dev/CHANGELOG.rst)
- [x] I have added my name to [AUTHORS]((https://github.com/oemof/oemof-tabular/tree/dev/AUTHORS.rst)
)
